### PR TITLE
Fix connection issue

### DIFF
--- a/lib/horde/registry.ex
+++ b/lib/horde/registry.ex
@@ -282,12 +282,7 @@ defmodule Horde.Registry do
     {:reply, {:ok, state.members}, state}
   end
 
-  defp generate_node_id(bits \\ 128) do
-    <<num::bits>> =
-      Enum.reduce(0..Integer.floor_div(bits, 8), <<>>, fn _x, bin ->
-        <<Enum.random(0..255)>> <> bin
-      end)
-
-    num
+  defp generate_node_id(bytes \\ 16) do
+    :base64.encode(:crypto.strong_rand_bytes(bytes))
   end
 end

--- a/lib/horde/uniform_distribution.ex
+++ b/lib/horde/uniform_distribution.ex
@@ -7,7 +7,7 @@ defmodule Horde.UniformDistribution do
     members =
       members
       |> Enum.filter(fn
-        {_, {:alive, _, _}} -> true
+        {_, {:alive, _}} -> true
         _ -> false
       end)
       |> Enum.sort_by(fn {node_id, _} -> node_id end)

--- a/lib/horde/uniform_quorum_distribution.ex
+++ b/lib/horde/uniform_quorum_distribution.ex
@@ -22,7 +22,7 @@ defmodule Horde.UniformQuorumDistribution do
       members ->
         alive_count =
           Enum.count(members, fn
-            {_, {:alive, _, _}} -> true
+            {_, {:alive, _}} -> true
             _ -> false
           end)
 
@@ -34,7 +34,7 @@ defmodule Horde.UniformQuorumDistribution do
     nodes =
       members
       |> Enum.reject(fn
-        {_, {:shutting_down, _, _}} -> true
+        {_, {:shutting_down, _}} -> true
         _ -> false
       end)
       |> Enum.sort_by(fn {node_id, _} -> node_id end)

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule Horde.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:delta_crdt, "== 0.1.9"},
+      {:delta_crdt, "== 0.1.10"},
       {:xxhash, "~> 0.1", github: "derekkraan/elixir-xxhash"},
       {:credo, "~> 0.9", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 0.5", only: :dev, runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -3,7 +3,7 @@
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "credo": {:hex, :credo, "0.9.2", "841d316612f568beb22ba310d816353dddf31c2d94aa488ae5a27bb53760d0bf", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:poison, ">= 0.0.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
   "deep_merge": {:hex, :deep_merge, "0.1.1", "c27866a7524a337b6a039eeb8dd4f17d458fd40fbbcb8c54661b71a22fffe846", [:mix], [], "hexpm"},
-  "delta_crdt": {:hex, :delta_crdt, "0.1.9", "67f4ed7af92cac9ff1ff1ef3d2c835f41e09f1e46997109b52f5b4d6e517fc5e", [:mix], [], "hexpm"},
+  "delta_crdt": {:hex, :delta_crdt, "0.1.10", "96aec91717c8a310423398c98103d749a2a1fdae219faff95110a232eb2e1c3e", [:mix], [], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},

--- a/test/uniform_distribution_test.exs
+++ b/test/uniform_distribution_test.exs
@@ -8,17 +8,17 @@ defmodule UniformDistributionTest do
                                status <- StreamData.member_of([:alive, :dead, :shutting_down]),
                                name <- binary(),
                                pid <- atom(:alias) do
-        {node_id, {status, pid, name}}
+        {node_id, {status, %{pid: pid, name: name}}}
       end
 
     check all members <- list_of(member),
               own_node_id <- integer(),
               identifier <- string(:alphanumeric) do
-      members = [{own_node_id, {:alive, :name, :pid}} | members]
+      members = [{own_node_id, {:alive, %{name: :name, pid: :pid}}} | members]
       chosen = Horde.UniformDistribution.choose_node(identifier, members)
 
       # it always chooses a node that's alive
-      assert {_, {:alive, _, _}} = chosen
+      assert {_, {:alive, _}} = chosen
 
       assert Enum.any?(members, fn
                ^chosen -> true


### PR DESCRIPTION
Fix reconnection issue.

What was happening:
If you connected to a horde, disconnected, and then connected again, things were going wrong.
Internally, the delta_crdt maintains a list of neighbours, and a map of neighbours to ack'ed deltas. The reference used for a neighbour was in this case of the form `{HelloWorld.HelloSupervisor, :"hello1@127.0.0.1"}` (in the case of the example app). The problem is: if this process were to die and be restarted, the reference would not change, so the neighbours would not send in the correct deltas.

The solution is to only communicate using pids. So now the neighbours list is a simple list of pids. This ensures that when these processes (or the entire node) are restarted, that the reference in the neighbours list is new.