### PR TITLE
Precheck for node connection in Registry.process_alive?/1

### DIFF
--- a/lib/horde/registry.ex
+++ b/lib/horde/registry.ex
@@ -108,7 +108,8 @@ defmodule Horde.Registry do
   defp process_alive?(pid) when node(pid) == node(self()), do: Process.alive?(pid)
 
   defp process_alive?(pid) do
-    :rpc.call(node(pid), Process, :alive?, [pid])
+    n = node(pid)
+    (Node.list() |> Enum.member?(n)) && :rpc.call(n, Process, :alive?, [pid])
   end
 
   defp get_ets_table(tab) when is_atom(tab), do: tab


### PR DESCRIPTION
When checking if a process is alive, check whether its node is visible before running an rpc on it. This lets the check fail fast if the node has been disconnected. We want this check to be fast since it is used by `Registry.lookup/2`. However, `:rpc.call/4` actually attempts to establish a connection if the node is not yet connected, and this could hang for a long time depending on the network state. (I run into this often when running on Kubernetes where I bring nodes up and down frequently.)