### PR TITLE
Trap exits in registry process so terminate gets called more reliably

### DIFF
--- a/lib/horde/registry.ex
+++ b/lib/horde/registry.ex
@@ -152,6 +152,8 @@ defmodule Horde.Registry do
   ### GenServer callbacks
 
   def init(opts) do
+    Process.flag(:trap_exit, true)
+
     node_id = generate_node_id()
 
     {:ok, members_pid} =
@@ -242,6 +244,10 @@ defmodule Horde.Registry do
     GenServer.reply(reply_to, :ok)
 
     {:noreply, %{state | members: members}}
+  end
+
+  def handle_info({:EXIT, _pid, reason}, state) do
+    {:stop, reason, state}
   end
 
   def handle_call({:join_hordes, other_horde}, from, state) do


### PR DESCRIPTION
I had to do this to address https://github.com/derekkraan/horde/issues/16 because I shut down registries often (when nodes go away). I know you're refactoring this module, so this may change or go away, but I wanted to make sure you knew.