### PR TITLE
Update xxhash version 0.2.0 => 0.2.1 for the example "Hello World" application. 

### DIFF
--- a/examples/hello_world/mix.lock
+++ b/examples/hello_world/mix.lock
@@ -1,5 +1,5 @@
 %{
   "delta_crdt": {:hex, :delta_crdt, "0.3.0", "c84803723edd6d0c9597a3e17ba0843bc6bef2e4997b5cd6d5865ba3e76acddd", [:mix], [], "hexpm"},
   "horde": {:git, "https://github.com/derekkraan/horde.git", "8822a432f4c3528f904bd62ddbb1bcc242658c93", [branch: "fix_start_children"]},
-  "xxhash": {:hex, :xxhash, "0.2.0", "4f5ca6159df3732eae22fd942494375d17fe09a66d7711c2e106fc64dfce2356", [:mix], [], "hexpm"},
+  "xxhash": {:hex, :xxhash, "0.2.1", "ab0893a8124f3c11116c57e500485dc5f67817d1d4c44f0fff41f3fd3c590607", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
The example app was referencing a previous version of xxhash which contained a bug that was fixed in the latest version. I discovered this while trying to run the hello world application. 

Updating to the latest version fixes the issue. 
Thanks for a great library. I am excited to play with it. 