### PR TITLE
Update example app to share data across the Horde.

### DIFF
--- a/examples/hello_world/README.md
+++ b/examples/hello_world/README.md
@@ -6,10 +6,14 @@ Start the app in two separate terminal windows with:
 
 `ERL_AFLAGS="-name count1@127.0.0.1 -setcookie asdf" HELLO_NODES="count2@127.0.0.1" iex -S mix`
 
-and 
+and
 
 `ERL_AFLAGS="-name count2@127.0.0.1 -setcookie asdf" HELLO_NODES="count1@127.0.0.1" iex -S mix`
 
 You should notice the message `HELLO from node X` printing in just one of the two instances. If you close that instance, you should (almost instantly) see the messages being output by the other instance.
 
-Other than that, this is a very minimal example of what one would need to do to get up and running with `Horde`. 
+We use the `meta/2` and `put_meta/3` functions on `Horde.Registry` to share the value for the counter across the members of the Horde. This means that when the node running `HelloWorld.SayHello` is killed, the new instance started by the `Horde.Supervisor` will pick up the counter from the meta data shared across the `Horde.Registry` to continue the count where the previous instance left off. You can get the count by running `HelloWorld.SayHello.how_many?`
+
+You can also call `HelloWorld.Application.how_many?` from any of the IEX consoles to retrieve the current value of the counter. 
+
+Other than that, this is a very minimal example of what one would need to do to get up and running with `Horde`.

--- a/examples/hello_world/lib/hello_world/application.ex
+++ b/examples/hello_world/lib/hello_world/application.ex
@@ -30,4 +30,8 @@ defmodule HelloWorld.Application do
     opts = [strategy: :one_for_one, name: HelloWorld.Supervisor]
     Supervisor.start_link(children, opts)
   end
+
+  def how_many?() do
+    Horde.Registry.meta(HelloWorld.HelloRegistry, "count")
+  end
 end

--- a/examples/hello_world/lib/hello_world/say_hello.ex
+++ b/examples/hello_world/lib/hello_world/say_hello.ex
@@ -15,20 +15,35 @@ defmodule HelloWorld.SayHello do
     GenServer.call(via_tuple(name), :how_many?)
   end
 
-  def init(args) do
+  def init(_args) do
     send(self(), :say_hello)
 
-    {:ok, 0}
+    {:ok, get_global_counter()}
   end
 
   def handle_info(:say_hello, counter) do
     IO.puts("HELLO from node #{inspect(Node.self())}")
     Process.send_after(self(), :say_hello, 5000)
-    {:noreply, counter + 1}
+
+    {:noreply, put_global_counter(counter + 1)}
   end
 
   def handle_call(:how_many?, _from, counter) do
     {:reply, counter, counter}
+  end
+
+  defp get_global_counter() do
+    case Horde.Registry.meta(HelloWorld.HelloRegistry, "count") do
+      {:ok, count} -> count
+      :error ->
+        put_global_counter(0)
+        get_global_counter()
+    end
+  end
+
+  defp put_global_counter(counter_value) do
+    :ok = Horde.Registry.put_meta(HelloWorld.HelloRegistry, "count", counter_value)
+    counter_value
   end
 
   def via_tuple(name), do: {:via, Horde.Registry, {HelloWorld.HelloRegistry, name}}


### PR DESCRIPTION
In the example we initialize the state of the `HelloWorld.SayHello` GenServer with the "count" value stored in `Horde.Registry` meta data. When `:say_hello` is received, we now also increment the "count" value. 

If the node running the single `HelloWorld.SayHello` instance is killed, and the supervisor starts a new instance, the state is read from the shared meta data and the counter continues where the previous instance of `SayHello` left off. 