### PR TITLE
Pass supervisor options through to SupervisorImpl

### DIFF
--- a/lib/horde/supervisor_supervisor.ex
+++ b/lib/horde/supervisor_supervisor.ex
@@ -23,7 +23,7 @@ defmodule Horde.SupervisorSupervisor do
        ship_interval: 50,
        ship_debounce: 400,
        shutdown: 30_000},
-      {Horde.SupervisorImpl, name: root_name},
+      {Horde.SupervisorImpl, Keyword.put(options, :name, root_name)},
       {Horde.GracefulShutdownManager,
        processes_pid: processes_crdt_name(root_name),
        name: graceful_shutdown_manager_name(root_name)},


### PR DESCRIPTION
I noticed that the default distribution_strategy in `SupervisorImpl` is Horde.UniformDistribution and that setting the `distritbution_strategy` in the options to `Horde.Supervisor` was not being passed through to allow one to override the `distribution_strategy` with something else. 

I think this change will allow that. It works for me locally. 