### PR TITLE
Use sha1 to generate string identifier of a term

### DIFF
--- a/lib/horde/process_supervisor.ex
+++ b/lib/horde/process_supervisor.ex
@@ -33,5 +33,8 @@ defmodule Horde.ProcessSupervisor do
     Supervisor.init(children, options)
   end
 
-  defp term_to_string_identifier(term), do: term |> :erlang.term_to_binary() |> Base.encode16()
+  defp term_to_string_identifier(term) do
+    binary = :erlang.term_to_binary(term)
+    :crypto.hash(:sha, binary) |> Base.encode16()
+  end
 end


### PR DESCRIPTION
When child_id of a process is converted to a binary it is possible that its length exceeds the system limit of atom length so I used SHA1 to always create a fixed size identifier of any child_id.