### PR TITLE
Return `:already_started` when starting an existing child

### DIFF
--- a/lib/horde/process_supervisor.ex
+++ b/lib/horde/process_supervisor.ex
@@ -22,14 +22,13 @@ defmodule Horde.ProcessSupervisor do
   def start_link(child_spec, graceful_shutdown_manager, registry_name, options) do
     Supervisor.start_link(
       __MODULE__,
-      {child_spec, graceful_shutdown_manager, registry_name, options}
+      {child_spec, graceful_shutdown_manager, options},
+      name: {:via, Registry, {registry_name, child_spec.id, nil}}
     )
   end
 
-  def init({child_spec, graceful_shutdown_manager, registry_name, options}) do
+  def init({child_spec, graceful_shutdown_manager, options}) do
     options = Keyword.put(options, :strategy, :one_for_one)
-
-    {:ok, _pid} = Registry.register(registry_name, child_spec.id, nil)
 
     children = [
       {Horde.ProcessCanary, {child_spec, graceful_shutdown_manager}}

--- a/lib/horde/supervisor_impl.ex
+++ b/lib/horde/supervisor_impl.ex
@@ -531,6 +531,14 @@ defmodule Horde.SupervisorImpl do
             {:ok, child_pid, term} ->
               {{:ok, child_pid, term}, child}
 
+            {:error, {error, {:child, _, _, _, _, _, _, _}}} ->
+              DynamicSupervisor.terminate_child(
+                processes_supervisor_name(state.name),
+                process_supervisor_pid
+              )
+
+              {:error, error}
+
             {:error, error} ->
               DynamicSupervisor.terminate_child(
                 processes_supervisor_name(state.name),

--- a/lib/horde/supervisor_impl.ex
+++ b/lib/horde/supervisor_impl.ex
@@ -540,6 +540,20 @@ defmodule Horde.SupervisorImpl do
               {:error, error}
           end
 
+        {:error, {:already_started, process_supervisor_pid}} ->
+          case Supervisor.start_child(process_supervisor_pid, child) do
+            {:error, {:already_started, child_pid}} ->
+              {:error, {:already_started, child_pid}}
+
+            {:error, error} ->
+              DynamicSupervisor.terminate_child(
+                processes_supervisor_name(state.name),
+                process_supervisor_pid
+              )
+
+              {:error, error}
+          end
+
         {:error, error} ->
           {:error, error}
       end


### PR DESCRIPTION
When starting an already started child, `start_child` must return
`:already_started` with pid of the already started child. To do so:

- name registeration of process supervisor should be done when we start
it, so to prevent from runnning a duplicate one if it's already started.
- When starting an already started child, first we try to start process
supervisor which returns `:already_started` with pid of the already started
process supervisor, in this case we need to retrieve pid of the child
running under this supervisor and return :alreay_started with that pid as the
result of the `start_child`