### PR TITLE
join_hordes and Registry race condition

### DIFF
--- a/examples/hello_world/lib/hello_world/application.ex
+++ b/examples/hello_world/lib/hello_world/application.ex
@@ -19,13 +19,14 @@ defmodule HelloWorld.Application do
         restart: :transient,
         start:
           {Task, :start_link,
-           [
-             fn ->
-               HelloWorld.ClusterConnector.connect()
-               HelloWorld.HordeConnector.connect()
-               Horde.Supervisor.start_child(HelloWorld.HelloSupervisor, HelloWorld.SayHello)
-             end
-           ]}
+            [
+              fn ->
+                HelloWorld.ClusterConnector.connect()
+                HelloWorld.HordeConnector.connect()
+                :timer.sleep(1000)
+                Horde.Supervisor.start_child(HelloWorld.HelloSupervisor, HelloWorld.SayHello)
+              end
+            ]}
       }
     ]
 

--- a/examples/hello_world/lib/hello_world/say_hello.ex
+++ b/examples/hello_world/lib/hello_world/say_hello.ex
@@ -28,7 +28,7 @@ defmodule HelloWorld.SayHello do
   end
 
   def handle_info(:say_hello, counter) do
-    Logger.info("HELLO from node #{inspect(Node.self())}")
+    Logger.info("HELLO from node #{inspect(Node.self())} at count #{counter}")
     Process.send_after(self(), :say_hello, 5000)
 
     {:noreply, put_global_counter(counter + 1)}


### PR DESCRIPTION
# Don't merge, just to show example...

When following the instructions in the example README.md, starting `count1` and `count2` followed by shutting down whichever node is performing the count, results in a restart of the count.

Looks like this is due to the registry synchronizing after joining the horde happens after the `SayHello` process is started and the global counter is fetched (which causes `SayHello` to overwrite it with 0).

## With the `:timer.sleep/1` commented out

### Start both

```
$ HELLO_NODES="count2@127.0.0.1" iex --name count1@127.0.0.1 --cookie asdf -S mix
...
$ HELLO_NODES="count1@127.0.0.1" iex --name count2@127.0.0.1 --cookie asdf -S mix
...
```

### On whichever tab is the counter

Kill and reboot the server. Count is properly transferred to the other node and continues running, but when the new node joins it is reset (the `SayHello` was started back on new node when I did it, perhaps this matters).

## With the `:timer.sleep/1`

After starting both, continuously killing the counter does not reset the count. The only way to lose the count is if all nodes go down (expected behavior).

(FYI, I was testing this with #68 changed locally, but I don't expect that has any connection to this issue)