### PR TITLE
ProcessSupervisor - Prevent crash if the worker is already registered and running.

### DIFF
--- a/lib/horde/process_supervisor.ex
+++ b/lib/horde/process_supervisor.ex
@@ -29,7 +29,10 @@ defmodule Horde.ProcessSupervisor do
   def init({child_spec, graceful_shutdown_manager, registry_name, options}) do
     options = Keyword.put(options, :strategy, :one_for_one)
 
-    {:ok, _pid} = Registry.register(registry_name, child_spec.id, nil)
+    case Registry.register(registry_name, child_spec.id, nil) do
+      {:ok, _pid} -> nil
+      {:error, {:already_registered, _pid}} -> nil # Don't care
+    end
 
     children = [
       {Horde.ProcessCanary, {child_spec, graceful_shutdown_manager}}


### PR DESCRIPTION
Best way I could reproduce this was to start the two nodes as fast as possible. Result is the following exception on one node:

```
22:18:19.170 [error] Process #PID<0.206.0> terminating
** (MatchError) no match of right hand side value: {:error, {:already_registered, #PID<0.203.0>}}
    (horde) lib/horde/process_supervisor.ex:32: Horde.ProcessSupervisor.init/1
    (stdlib) supervisor.erl:294: :supervisor.init/1
    (stdlib) gen_server.erl:365: :gen_server.init_it/2
    (stdlib) gen_server.erl:333: :gen_server.init_it/6
    (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
Initial Call: Horde.ProcessSupervisor.init/1
Ancestors: [HelloWorld.HelloSupervisor.ProcessesSupervisor, HelloWorld.HelloSupervisor.Supervisor, HelloWorld.Supervisor, #PID<0.168.0>]
Message Queue Length: 0
Messages: []
Links: [#PID<0.198.0>]
Dictionary: []
Trapping Exits: true
Status: :running
Heap Size: 610
Stack Size: 27
Reductions: 220
```

And on the other node, the following debug message is printed out:

```
22:18:19.139 [debug] Joining a horde failed. Details: {:timeout, {GenServer, :call, [HelloWorld.HelloSupervisor, {:join_hordes, {HelloWorld.HelloSupervisor, :"count2@127.0.0.1"}}, 5000]}}

22:18:37.971 [debug] Found 1 processes on dead nodes
```

**With this PR, the above joining failed messaging still occurs, so perhaps there is still something left to fix for this condition.**