### PR TITLE
fix warning

### DIFF
--- a/lib/horde/registry_impl.ex
+++ b/lib/horde/registry_impl.ex
@@ -185,7 +185,7 @@ defmodule Horde.RegistryImpl do
     mark_dead(state, n)
 
     Enum.each(DeltaCrdt.read(state.keys_pid, 30_000), fn
-      {key, {pid, value}} when node(pid) == n ->
+      {key, {pid, _value}} when node(pid) == n ->
         DeltaCrdt.mutate_async(state.keys_pid, :remove, [key])
         :ets.match_delete(state.keys_ets_table, {key, {pid, :_}})
 


### PR DESCRIPTION
```
warning: variable "value" is unused (if the variable is not meant to be used, prefix it with an underscore)
  lib/horde/registry_impl.ex:188
```