### PR TITLE
fix cannot start supervisor children after calling `set_members`

### DIFF
--- a/lib/horde/supervisor_impl.ex
+++ b/lib/horde/supervisor_impl.ex
@@ -428,7 +428,7 @@ defmodule Horde.SupervisorImpl do
     new_members_info =
       Map.merge(
         uninitialized_new_members_info,
-        Map.take(state.members, Map.keys(uninitialized_new_members_info))
+        Map.take(state.members_info, Map.keys(uninitialized_new_members_info))
       )
 
     new_members = Map.new(new_members_info, fn {member, _} -> {member, 1} end)

--- a/test/cluster_test.exs
+++ b/test/cluster_test.exs
@@ -97,5 +97,12 @@ defmodule ClusterTest do
       Process.sleep(200)
       assert 1 = Enum.count(members)
     end
+
+    test "supervisor can start child" do
+      {:ok, _} = start_supervised({Horde.Supervisor, [name: :sup, strategy: :one_for_one]})
+      assert :ok = Horde.Cluster.set_members(:sup, [:sup])
+      {:ok, child_pid} = Supervisor.start_child(:sup, {Task, fn -> :ok end})
+      assert is_pid(child_pid)
+    end
   end
 end

--- a/test/cluster_test.exs
+++ b/test/cluster_test.exs
@@ -78,7 +78,7 @@ defmodule ClusterTest do
 
       assert :ok = Horde.Cluster.set_members(:sup6, [:sup6])
 
-      {:ok, [sup6: nonode]} = Horde.Cluster.members(:sup6)
+      {:ok, [sup6: _nonode]} = Horde.Cluster.members(:sup6)
     end
 
     test "can join and unjoin registry with set_members" do


### PR DESCRIPTION
Using horde version 0.5-pre, starting a supervisor child after calling `Horde.Cluster.set_members/2` fails with the following error:

```
[error] GenServer :sup0 terminating                                
** (ArithmeticError) bad argument in arithmetic expression                      
    :erlang.rem(1548551151, 0)                                                  
    (horde) lib/horde/uniform_distribution.ex:17: Horde.UniformDistribution.choose_node/2                                                                       
    (horde) lib/horde/supervisor_impl.ex:151: Horde.SupervisorImpl.handle_call/3
    (stdlib) gen_server.erl:661: :gen_server.try_handle_call/4                  
    (stdlib) gen_server.erl:690: :gen_server.handle_msg/6                       
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3                      
Last message (from #PID<0.181.0>): {:start_child, %{id: Task, restart: :temporary, start: {Task, :start_link, [#Function<0.115226832/0 in ClusterTest."test .set_members/2 supervisor can start child"/1>]}}}                                   
State: %Horde.SupervisorImpl{distribution_strategy: Horde.UniformDistribution, members: %{{:sup0, :nonode@nohost} => 1}, members_info: %{{:sup0, :nonode@nohost} => 1}, name: :sup0, name_to_supervisor_ref: %{{:sup0, :nonode@nohost} => #Reference<0.263759051.1740111875.157871>}, processes: %{}, processes_updated_at: 0, processes_updated_counter: 0, shutting_down: false, supervisor_options: [name: :sup0, root_name: :sup0, members: [:sup0], strategy: :one_for_one], supervisor_ref_to_name: %{#Reference<0.263759051.1740111875.157871> => {:sup0, :nonode@nohost}}, waiting_for_quorum: []}                                                      
Client #PID<0.181.0> is alive
```

This PR should fix it (and it adds a simple test exposing the bug).