### PR TITLE
An exception is raised when `Horde.UniformDistribution.choose_node/2` and no alive members are available

### DIFF
--- a/lib/horde/uniform_distribution.ex
+++ b/lib/horde/uniform_distribution.ex
@@ -14,9 +14,14 @@ defmodule Horde.UniformDistribution do
       end)
       |> Enum.sort_by(fn %{name: name} -> name end)
 
-    index = XXHash.xxh32(term_to_string_identifier(identifier)) |> rem(Enum.count(members))
+    case Enum.count(members) do
+      0 ->
+        {:error, :no_alive_nodes}
 
-    {:ok, Enum.at(members, index)}
+      count ->
+        index = XXHash.xxh32(term_to_string_identifier(identifier)) |> rem(count)
+        {:ok, Enum.at(members, index)}
+    end
   end
 
   def has_quorum?(_members), do: true

--- a/test/uniform_distribution_test.exs
+++ b/test/uniform_distribution_test.exs
@@ -26,4 +26,21 @@ defmodule UniformDistributionTest do
              end)
     end
   end
+
+  property "returns error if no alive nodes are available" do
+    member =
+      ExUnitProperties.gen all node_id <- integer(1..100_000),
+                               status <- StreamData.member_of([:dead, :shutting_down]),
+                               name <- binary(),
+                               pid <- atom(:alias) do
+        %{node_id: node_id, status: status, pid: pid, name: name}
+      end
+
+    check all members <- list_of(member),
+              identifier <- string(:alphanumeric) do
+      choice = Horde.UniformDistribution.choose_node(identifier, members)
+
+      assert {:error, :no_alive_nodes} = choice
+    end
+  end
 end


### PR DESCRIPTION
If all cluster members are in `:dead` or `:shutting_down` state, when `choose_node/2` is called an exception is raised because a division by zero is attempted.
This often happens in tests, because of the fast termination of cluster members (it happens in horde's supervisor tests too).

Here i added a return value of `{:error, :no_alive_nodes}` when no nodes are available, similar to what happens in the uniform quorum distribution case.

A test is added to expose the bug.