### PR TITLE
Add registry select/4

### DIFF
--- a/lib/horde/registry.ex
+++ b/lib/horde/registry.ex
@@ -240,6 +240,25 @@ defmodule Horde.Registry do
     :ets.match(keys_ets_table(registry), :"$1") |> Map.new(fn [{k, _m, v}] -> {k, v} end)
   end
 
+  @doc """
+  Select key, pid, and values from the process registry of the horde
+  """
+  def select(registry, spec) when is_atom(registry) and is_list(spec) do
+    spec =
+      for part <- spec do
+        case part do
+          {{key, pid, value}, guards, select} ->
+            {{key, {registry, :_}, {pid, value}}, guards, select}
+
+          _ ->
+            raise ArgumentError,
+                  "invalid match specification in Registry.select/2: #{inspect(spec)}"
+        end
+      end
+
+      :ets.select(keys_ets_table(registry), spec)
+  end
+
   ### Via callbacks
 
   @doc false


### PR DESCRIPTION
## PR Checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

Feature

## What is the current behaviour ?

Fixes: #101

## What is the new behaviour ?

As for `match/4`, this is a new function used to match on the keys instead.

## Does this PR introduce a breaking change?

No

## Additional context

@derekkraan Is there a code convention or a commit naming convention to respect? I would like to contribute more and looking to improve documentation.
