### PR TITLE
Registry: Prevent local duplicate registration

### DIFF
--- a/lib/horde/registry.ex
+++ b/lib/horde/registry.ex
@@ -115,7 +115,13 @@ defmodule Horde.Registry do
           value :: Registry.value()
         ) :: {:ok, pid()} | {:error, :already_registered, pid()}
   def register(registry, name, value) when is_atom(registry) do
-    GenServer.call(registry, {:register, name, value, self()})
+    case :ets.lookup(keys_ets_table(registry), name) do
+      [] ->
+        GenServer.call(registry, {:register, name, value, self()})
+
+      [{^name, _member, {pid, _value}}] ->
+        {:error, {:already_registered, pid}}
+    end
   end
 
   @doc "unregister the process under the given name"


### PR DESCRIPTION
This patch makes Registry.register/3 more in line with its Elixir
equivalent. In fact, I copied the test cases from Elixir's Registry.

Duplicate registrations can still happen (overwrite each other) within
members of the cluster. This will be dealt with in another PR