### PR TITLE
More compatible with DynamicSupervisor

### DIFF
--- a/lib/horde/horde_dynamic_supervisor.ex
+++ b/lib/horde/horde_dynamic_supervisor.ex
@@ -1049,6 +1049,7 @@ defmodule Horde.DynamicSupervisor do
       {:ok, %{strategy: strategy} = state} ->
         case restart_child(strategy, pid, child, state) do
           {:ok, state} ->
+            update_child_pid_horde(child, state)
             {:ok, state}
 
           {:try_again, state} ->
@@ -1060,6 +1061,12 @@ defmodule Horde.DynamicSupervisor do
         report_error(:shutdown, :reached_max_restart_intensity, pid, child, state)
         {:shutdown, delete_child(pid, state)}
     end
+  end
+
+  defp update_child_pid_horde({child_id, _, _, _, _, _}, state) do
+    %{child_id_to_pid: child_id_to_pid} = state
+    new_pid = Map.get(child_id_to_pid, child_id)
+    GenServer.call(state.root_name, {:update_child_pid, child_id, new_pid})
   end
 
   defp add_restart(state) do

--- a/lib/horde/supervisor.ex
+++ b/lib/horde/supervisor.ex
@@ -142,10 +142,10 @@ defmodule Horde.Supervisor do
   @doc """
   Terminate a child process.
 
-  Unlike `DynamicSupervisor.terminate_child/2`, this function expects a child_id, and not a pid.
+  Works like `DynamicSupervisor.terminate_child/2`.
   """
-  @spec terminate_child(Supervisor.supervisor(), child_id :: term()) :: :ok | {:error, :not_found}
-  def terminate_child(supervisor, child_id), do: call(supervisor, {:terminate_child, child_id})
+  @spec terminate_child(Supervisor.supervisor(), child_pid :: pid()) :: :ok | {:error, :not_found}
+  def terminate_child(supervisor, child_pid), do: call(supervisor, {:terminate_child, child_pid})
 
   @doc """
   Works like `DynamicSupervisor.which_children/1`.


### PR DESCRIPTION
This PR increases compatability with DynamicSupervisor.

Changes:
- `start_child/2` ignores any `id` in the child_sped argument, and generates its own id for internal use.
- `terminate_child/2` accepts a pid as second argument instead of an id
- `which_children/1` now returns `{:undefined, pid, type, modules}`

This PR should solve the following issues: #82, #54.

This PR also means `Horde.Supervisor` no longer dedups processes across a cluster. Just like `Elixir.DynamicSupervisor`, you're expected to use `Horde.Registry` to gain this functionality.
