### PR TITLE
[POC] Name conflicts don't count towards the max restart intensity

### DIFF
--- a/test/registry_test.exs
+++ b/test/registry_test.exs
@@ -262,7 +262,7 @@ defmodule RegistryTest do
       Horde.Cluster.set_members(horde1, [horde1, horde2])
 
       {:ok, _} = Horde.Registry.register(horde1, "a", :value)
-      Process.sleep(100)
+      Process.sleep(200)
 
       assert ["a"] = Horde.Registry.select(horde1, [{{:"$1", :_, :_}, [], [:"$1"]}])
       assert ["a"] = Horde.Registry.select(horde2, [{{:"$1", :_, :_}, [], [:"$1"]}])
@@ -342,8 +342,7 @@ defmodule RegistryTest do
           "doesn't match"
         )
 
-      assert [{self(), "match_unregister"}] ==
-               Horde.Registry.lookup(horde, "to_unregister")
+      assert [{self(), "match_unregister"}] == Horde.Registry.lookup(horde, "to_unregister")
 
       assert ["to_unregister"] = Horde.Registry.keys(horde, self())
 

--- a/test/supervisor_test.exs
+++ b/test/supervisor_test.exs
@@ -160,7 +160,7 @@ defmodule SupervisorTest do
           Map.put(context.task_def, :id, "kill_me")
         )
 
-      Process.sleep(100)
+      Process.sleep(200)
 
       :ok = Horde.Supervisor.terminate_child(context.horde_1, pid)
     end


### PR DESCRIPTION
These name conflicts are not real failures, so we don't want them to
trigger max restart intensity. In the event of a netsplit that is
healing, there may be a LOT of these happening, so it's almost
guaranteed that we would exceed the max restart intensity.

Should fix #116 

Note: I'm not sure this is actually a good idea, since we are letting the supervisor know about a detail of the registry.

~This PR also needs a test.~