### PR TITLE
Do not crash when trying to send a CRDT update to the root name

### DIFF
--- a/lib/horde/registry_supervisor.ex
+++ b/lib/horde/registry_supervisor.ex
@@ -14,7 +14,7 @@ defmodule Horde.RegistrySupervisor do
     children = [
       {DeltaCrdt,
        crdt: DeltaCrdt.AWLWWMap,
-       on_diffs: fn diffs -> send(root_name, {:crdt_update, diffs}) end,
+       on_diffs: fn diffs -> on_diffs(diffs, root_name) end,
        name: crdt_name(root_name),
        sync_interval: 100},
       {Horde.RegistryImpl,
@@ -35,6 +35,16 @@ defmodule Horde.RegistrySupervisor do
     end
 
     root_name
+  end
+
+  defp on_diffs(diffs, root_name) do
+    try do
+      send(root_name, {:crdt_update, diffs})
+    rescue
+      ArgumentError ->
+        # the process might already been stopped
+        :ok
+    end
   end
 
   def crdt_name(name), do: :"#{name}.Crdt"

--- a/lib/horde/supervisor_supervisor.ex
+++ b/lib/horde/supervisor_supervisor.ex
@@ -9,7 +9,7 @@ defmodule Horde.SupervisorSupervisor do
     children = [
       {DeltaCrdt,
        crdt: DeltaCrdt.AWLWWMap,
-       on_diffs: fn diffs -> send(root_name, {:crdt_update, diffs}) end,
+       on_diffs: fn diffs -> on_diffs(diffs, root_name) end,
        name: crdt_name(root_name),
        sync_interval: 100,
        shutdown: 30_000},
@@ -36,6 +36,16 @@ defmodule Horde.SupervisorSupervisor do
     end
 
     root_name
+  end
+
+  defp on_diffs(diffs, root_name) do
+    try do
+      send(root_name, {:crdt_update, diffs})
+    rescue
+      ArgumentError ->
+        # the process might already been stopped
+        :ok
+    end
   end
 
   defp supervisor_name(name), do: :"#{name}.ProcessesSupervisor"


### PR DESCRIPTION
Sending the diff might fail (with an ArgumentError) because on
shutdown, the supervisor is already stopped, and thus, the root name
is not registered anymore in the process registry.