### PR TITLE
Hash the child spec minus the id for consistent hashing.

### DIFF
--- a/lib/horde/supervisor_impl.ex
+++ b/lib/horde/supervisor_impl.ex
@@ -141,8 +141,10 @@ defmodule Horde.SupervisorImpl do
 
     child_spec = Map.put(child_spec, :id, :rand.uniform(@big_number))
 
+    distribution_id = :erlang.phash2(Map.drop(child_spec, [:id]))
+
     case state.distribution_strategy.choose_node(
-           child_spec.id,
+           distribution_id,
            Map.values(members(state))
          ) do
       {:ok, %{name: ^this_name}} ->

--- a/lib/horde/uniform_distribution.ex
+++ b/lib/horde/uniform_distribution.ex
@@ -19,10 +19,13 @@ defmodule Horde.UniformDistribution do
         {:error, :no_alive_nodes}
 
       count ->
-        index = XXHash.xxh32(term_to_string_identifier(identifier)) |> rem(count)
+        index = hash(term_to_string_identifier(identifier)) |> rem(count)
         {:ok, Enum.at(members, index)}
     end
   end
+
+  defp hash(identifier) when is_integer(identifier), do: identifier
+  defp hash(identifier), do: :erlang.phash2(identifier)
 
   def has_quorum?(_members), do: true
 

--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,6 @@ defmodule Horde.MixProject do
   defp deps do
     [
       {:delta_crdt, "== 0.5.1"},
-      {:xxhash, "~> 0.1"},
       {:ex_doc, "~> 0.16", only: :dev, runtime: false},
       {:benchee, "> 0.0.1", only: :dev, runtime: false},
       {:stream_data, "~> 0.4", only: :test},


### PR DESCRIPTION
With #122 we started assigning random ids to bring us in line with DynamicSupervisor's API. This broke consistent hashing. This PR restores that, by hashing the child spec minus the id.

Caveat: if you are starting processes that only differ by the id, and want them to end up on different nodes, then you will have to add something to the child_spec to differentiate them, or alternatively supply your own distribution_strategy.

Also removes xxhash as dependency.

_This PR needs a test._