### PR TITLE
Message of set_members documented

### DIFF
--- a/lib/horde/cluster.ex
+++ b/lib/horde/cluster.ex
@@ -3,6 +3,8 @@ defmodule Horde.Cluster do
 
   @moduledoc """
   Public functions to join and leave hordes.
+  It will also send a :set_members call to every member of the horde Cluster,
+  with content members [{member_one_name, member_one_node}, {member...}]
 
   Calling `Horde.Cluster.set_members/2` will join the given members in a cluster. Cluster membership is propagated via a CRDT, so setting it once on a single node is sufficient.
   ```elixir


### PR DESCRIPTION
I tried to implement a DeltaCrdt handoff using the Tanx example from 2018, 
I was not able to understand where the message :set_members originated. 
Maybe it is already documented in hex, however I have not found it on the first glance.