### PR TITLE
Fix via register with meta

### DIFF
--- a/lib/horde/registry.ex
+++ b/lib/horde/registry.ex
@@ -305,9 +305,10 @@ defmodule Horde.Registry do
 
   @doc false
   # @spec register_name({pid, term}, pid) :: :yes | :no
-  def register_name({registry, key}, pid), do: register_name({registry, key, nil}, pid)
+  def register_name({registry, key}, pid), do: register_name(registry, key, nil, pid)
+  def register_name({registry, key, value}, pid), do: register_name(registry, key, value, pid)
 
-  def register_name({registry, key, value}, pid) when is_atom(registry) do
+  defp register_name(registry, key, value, pid) when is_atom(registry) do
     case GenServer.call(registry, {:register, key, value, pid}) do
       {:ok, _pid} -> :yes
       {:error, _} -> :no
@@ -316,7 +317,10 @@ defmodule Horde.Registry do
 
   @doc false
   # @spec whereis_name({pid, term}) :: pid | :undefined
-  def whereis_name({registry, name}) when is_atom(registry) do
+  def whereis_name({registry, key}), do: whereis_name(registry, key)
+  def whereis_name({registry, key, _value}), do: whereis_name(registry, key)
+
+  defp whereis_name(registry, name) when is_atom(registry) do
     case lookup(registry, name) do
       :undefined -> :undefined
       [{pid, _val}] -> pid


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

**Bugfix**

## What is the current behavior?

We got a `MatchError`.

## What is the new behaviour?

We can now register our process with metadata:

```elixir
{:ok, _} = Horde.Registry.start_link(keys: :unique, name: Horde.Registry.ViaTest)
name = {:via, Horde.Registry, {Horde.Registry.ViaTest, "agent", :hello}}
{:ok, _} = Agent.start_link(fn -> 0 end, name: name)
Horde.Registry.lookup(Horde.Registry.ViaTest, "agent")
#=> [{self(), :hello}]
```

## Does this PR introduce a breaking change?

**No**
