### PR TITLE
Ensure Registry.child_spec/1 overridable.

### DIFF
--- a/test/support/module_based_registry.ex
+++ b/test/support/module_based_registry.ex
@@ -13,3 +13,46 @@ defmodule TestRegistry2 do
     {:ok, Keyword.put(options, :members, [:init_test_1, :init_test_2])}
   end
 end
+
+defmodule TestRegistry3 do
+  use Horde.Registry
+  @base_opts [keys: :unique, name: __MODULE__]
+
+  @impl true
+  def init(options) do
+    {:ok, Keyword.put(options, :members, [:init_test_1, :init_test_2])}
+  end
+
+  @impl true
+  def child_spec(args) do
+    %{
+      id: args[:custom_id],
+      start: {__MODULE__, :start_link, [Keyword.merge(@base_opts, args)]},
+      restart: :transient,
+      type: :supervisor
+    }
+  end
+end
+
+defmodule TestRegistry4 do
+  use Horde.Registry,
+    restart: :transient,
+    # value provided to differ from default :supervisor option
+    type: :worker
+
+  @base_opts [keys: :unique, name: __MODULE__]
+
+  @impl true
+  def init(options) do
+    {:ok, Keyword.put(options, :members, [:init_test_1, :init_test_2])}
+  end
+
+  @impl true
+  def child_spec(args) do
+    args
+    |> super
+    |> Map.merge(%{
+      start: {__MODULE__, :start_link, [Keyword.merge(@base_opts, args)]}
+    })
+  end
+end

--- a/test/uniform_distribution_test.exs
+++ b/test/uniform_distribution_test.exs
@@ -4,16 +4,20 @@ defmodule UniformDistributionTest do
 
   property "chooses one of the members" do
     member =
-      ExUnitProperties.gen all node_id <- integer(1..100_000),
-                               status <- StreamData.member_of([:alive, :dead, :shutting_down]),
-                               name <- binary(),
-                               pid <- atom(:alias) do
+      ExUnitProperties.gen all(
+                             node_id <- integer(1..100_000),
+                             status <- StreamData.member_of([:alive, :dead, :shutting_down]),
+                             name <- binary(),
+                             pid <- atom(:alias)
+                           ) do
         %{node_id: node_id, status: status, pid: pid, name: "A#{name}"}
       end
 
-    check all members <- list_of(member),
-              own_node_id <- integer(),
-              identifier <- string(:alphanumeric) do
+    check all(
+            members <- list_of(member),
+            own_node_id <- integer(),
+            identifier <- string(:alphanumeric)
+          ) do
       members = [%{node_id: own_node_id, status: :alive, name: :name, pid: :pid} | members]
       choice = Horde.UniformDistribution.choose_node(identifier, members)
 
@@ -29,15 +33,19 @@ defmodule UniformDistributionTest do
 
   property "returns error if no alive nodes are available" do
     member =
-      ExUnitProperties.gen all node_id <- integer(1..100_000),
-                               status <- StreamData.member_of([:dead, :shutting_down]),
-                               name <- binary(),
-                               pid <- atom(:alias) do
+      ExUnitProperties.gen all(
+                             node_id <- integer(1..100_000),
+                             status <- StreamData.member_of([:dead, :shutting_down]),
+                             name <- binary(),
+                             pid <- atom(:alias)
+                           ) do
         %{node_id: node_id, status: status, pid: pid, name: name}
       end
 
-    check all members <- list_of(member),
-              identifier <- string(:alphanumeric) do
+    check all(
+            members <- list_of(member),
+            identifier <- string(:alphanumeric)
+          ) do
       choice = Horde.UniformDistribution.choose_node(identifier, members)
 
       assert {:error, :no_alive_nodes} = choice

--- a/test/uniform_quorum_distribution_test.exs
+++ b/test/uniform_quorum_distribution_test.exs
@@ -4,19 +4,23 @@ defmodule UniformQuorumDistributionTest do
 
   property "chooses one of the members" do
     member =
-      ExUnitProperties.gen all node_id <- integer(1..100_000),
-                               status <- StreamData.member_of([:alive, :dead, :shutting_down]),
-                               name <- binary(),
-                               pid <- atom(:alias) do
+      ExUnitProperties.gen all(
+                             node_id <- integer(1..100_000),
+                             status <- StreamData.member_of([:alive, :dead, :shutting_down]),
+                             name <- binary(),
+                             pid <- atom(:alias)
+                           ) do
         %{node_id: node_id, status: status, pid: pid, name: "A#{name}"}
       end
 
-    check all members <-
-                uniq_list_of(member,
-                  min_length: 2,
-                  uniq_fun: fn %{node_id: node_id} -> node_id end
-                ),
-              identifier <- string(:alphanumeric) do
+    check all(
+            members <-
+              uniq_list_of(member,
+                min_length: 2,
+                uniq_fun: fn %{node_id: node_id} -> node_id end
+              ),
+            identifier <- string(:alphanumeric)
+          ) do
       partition_a = members
 
       partition_b =


### PR DESCRIPTION
* `child_spec` configurable with inline options during `use` like for regular `GenServer`
* `child_spec` can be redefined and refined with `super`