### PR TITLE
update libcluster guide

### DIFF
--- a/guides/libcluster.md
+++ b/guides/libcluster.md
@@ -9,15 +9,23 @@ There are two strategies you can use to integrate libcluster with Horde:
 If you will not be adding or removing members from the cluster dynamically, then you can set up libcluster and tell Horde about the members of your cluster. For example, if you run your cluster on bare metal hardware and have a fixed number of servers.
 
 ```elixir
-members = [
+supervisor_members = [
   {MyHordeSupervisor, :node1},
   {MyHordeSupervisor, :node2},
   {MyHordeSupervisor, :node3},
   {MyHordeSupervisor, :node4}
 ]
 
+registry_members = [
+  {MyHordeRegistry, :node1},
+  {MyHordeRegistry, :node2},
+  {MyHordeRegistry, :node3},
+  {MyHordeRegistry, :node4}
+]
+
 children = [
-  {Horde.Supervisor, name: MyHordeSupervisor, strategy: :one_for_one, members: members},
+  {Horde.Registry, name: MyHordeRegistry, keys: :unique, members: registry_members},
+  {Horde.Supervisor, name: MyHordeSupervisor, strategy: :one_for_one, members: supervisor_members},
   ...
 ]
 ```
@@ -28,7 +36,7 @@ This is the simplest approach. You tell Horde which members are supposed to be i
 
 If you will be adding and removing nodes from your cluster constantly, and don't want to repackage your application every time you do this, then you will need to perform a couple of extra steps.
 
-In this scenario, you will need to implement a [module-based Supervisor](Horde.Supervisor.html#module-module-based-supervisor)
+In this scenario, you will need to implement a [module-based Supervisor](https://hexdocs.pm/horde/Horde.Supervisor.html#module-module-based-supervisor)
 
 ```elixir
 defmodule MyHordeSupervisor do
@@ -47,6 +55,25 @@ end
 
 Now every time `MyHordeSupervisor` gets started or restarted, it will compute the members based on the currently connected members.
 
+In this scenario, you may also want to implement a [module-based Registry](https://hexdocs.pm/horde/Horde.Registry.html#module-module-based-registry)
+
+```elixir
+defmodule MyHordeRegistry do
+  use Horde.Registry
+
+  def init(options) do
+    {:ok, Keyword.put(options, :members, get_members())}
+  end
+
+  defp get_members() do
+    [Node.self() | Node.list()]
+    |> Enum.map(fn node -> {MyHordeRegistry, node} end)
+  end
+end
+```
+
+Now every time `MyHordeRegistry` gets started or restarted, it will compute the members based on the currently connected members.
+
 We also need a separate process that will listen for `{:nodeup, node}` and `{:nodedown, node}` events and adjust the members of the Horde cluster accordingly. Put this in your supervision tree underneath `MyHordeSupervisor`.
 
 ```elixir
@@ -61,11 +88,13 @@ defmodule NodeListener do
   end
 
   def handle_info({:nodeup, _node, _node_type}, state) do
+    set_members(MyHordeRegistry)
     set_members(MyHordeSupervisor)
     {:noreply, state}
   end
 
   def handle_info({:nodedown, _node, _node_type}, state) do
+    set_members(MyHordeRegistry)
     set_members(MyHordeSupervisor)
     {:noreply, state}
   end

--- a/guides/libcluster.md
+++ b/guides/libcluster.md
@@ -53,23 +53,25 @@ We also need a separate process that will listen for `{:nodeup, node}` and `{:no
 defmodule NodeListener do
   use GenServer
 
+  def start_link(), do: GenServer.start_link(__MODULE__, [])
+
   def init(_) do
     :net_kernel.monitor_nodes(true, node_type: :visible)
     {:ok, nil}
   end
 
-  def handle_info({:nodeup, _node}, state) do
+  def handle_info({:nodeup, _node, _node_type}, state) do
     set_members(MyHordeSupervisor)
     {:noreply, state}
   end
 
-  def handle_info({:nodedown, _node}, state) do
+  def handle_info({:nodedown, _node, _node_type}, state) do
     set_members(MyHordeSupervisor)
     {:noreply, state}
   end
 
   defp set_members(name) do
-    members = 
+    members =
     [Node.self() | Node.list()]
     |> Enum.map(fn node -> {name, node} end)
     :ok = Horde.Cluster.set_members(name, members)


### PR DESCRIPTION
@derekkraan We should also be adding our Registry to `set_members` here, correct? If so, I'll add this into the readme, so it will create less confusion for others.

```elixir
  def handle_info({:nodeup, _node, _node_type}, state) do
    set_members(MyHordeRegistry)
    set_members(MyHordeSupervisor)
    {:noreply, state}
  end

  def handle_info({:nodedown, _node, _node_type}, state) do
    set_members(MyHordeRegistry)
    set_members(MyHordeSupervisor)
    {:noreply, state}
  end
```

-- Shawn 