### PR TITLE
handle_info :name_conflict with correct :EXIT match

### DIFF
--- a/guides/eventual_consistency.md
+++ b/guides/eventual_consistency.md
@@ -25,7 +25,7 @@ def init(arg) do
   {:ok, state}
 end
 
-def handle_info({:name_conflict, {key, value}, registry, pid}, state) do
+def handle_info({:EXIT, _from, {:name_conflict, {key, value}, registry, pid}}, state) do
   # handle the message, add some logging perhaps, and probably stop the GenServer.
   {:stop, state}
 end


### PR DESCRIPTION
We encountered a small error in the guides. When trapping exits, the actual message is wrapped in an {:exit, from, reason} tuple.