### PR TITLE
Add netsplit test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,3 @@ horde-*.tar
 .tool-versions
 
 *.app
-.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ horde-*.tar
 .tool-versions
 
 *.app
+.DS_Store

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,10 @@ defmodule Horde.MixProject do
       docs: docs(),
       package: package(),
       name: "Horde",
-      source_url: "https://github.com/derekkraan/horde"
+      source_url: "https://github.com/derekkraan/horde",
+      aliases: [
+        test: "test --no-start"
+      ]
     ]
   end
 
@@ -33,7 +36,7 @@ defmodule Horde.MixProject do
       {:ex_doc, "~> 0.16", only: :dev, runtime: false},
       {:benchee, "> 0.0.1", only: :dev, runtime: false},
       {:stream_data, "~> 0.4", only: :test},
-      {:local_cluster, "~> 1.0.4", only: :test},
+      {:local_cluster, "~> 1.1", only: :test},
       {:schism, "~> 1.0.1", only: :test}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -6,7 +6,7 @@
   "ex_doc": {:hex, :ex_doc, "0.20.2", "1bd0dfb0304bade58beb77f20f21ee3558cc3c753743ae0ddbb0fd7ba2912331", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "global_flags": {:hex, :global_flags, "1.0.0", "ee6b864979a1fb38d1fbc67838565644baf632212bce864adca21042df036433", [:rebar3], [], "hexpm"},
   "libring": {:hex, :libring, "1.4.0", "41246ba2f3fbc76b3971f6bce83119dfec1eee17e977a48d8a9cfaaf58c2a8d6", [:mix], [], "hexpm"},
-  "local_cluster": {:hex, :local_cluster, "1.0.4", "3cabf9b267cf276752ee6ceccdbe3a05a2125da1b93c5bb74b586ae4539ebd66", [:mix], [{:global_flags, "~> 1.0", [hex: :global_flags, repo: "hexpm", optional: false]}], "hexpm"},
+  "local_cluster": {:hex, :local_cluster, "1.1.0", "a2a0e3e965aa1549939108066bfa537ce89f0107917f5b0260153e2fdb304116", [:mix], [{:global_flags, "~> 1.0", [hex: :global_flags, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "merkle_map": {:hex, :merkle_map, "0.2.0", "5391ac61e016ce4aeb66ce39f05206a382fd4b66ee4b63c08a261d5633eadd76", [:mix], [], "hexpm"},

--- a/test/local_cluster_test.exs
+++ b/test/local_cluster_test.exs
@@ -21,6 +21,7 @@ defmodule LocalClusterTest do
     [nodes: nodes]
   end
 
+  @tag skip: true
   test "a heal after a netsplit should ensure the process keeps running", %{
     nodes: [n1, n2] = nodes
   } do

--- a/test/local_cluster_test.exs
+++ b/test/local_cluster_test.exs
@@ -1,0 +1,137 @@
+defmodule LocalClusterTest do
+  require Logger
+  use ExUnit.Case, async: false
+
+  setup do
+    nodes = LocalCluster.start_nodes("cluster-#{:rand.uniform(1000)}", 2)
+
+    _ =
+      for n <- nodes do
+        {:ok, _} =
+          rpc(n, Horde.Supervisor, :start_link, [[name: TestSup, strategy: :one_for_one]])
+
+        {:ok, _} = rpc(n, Horde.Registry, :start_link, [[name: TestReg, keys: :unique]])
+        reg_members = for n <- nodes, do: {TestReg, n}
+        :ok = rpc(n, Horde.Cluster, :set_members, [TestReg, reg_members])
+
+        sup_members = for n <- nodes, do: {TestSup, n}
+        :ok = rpc(n, Horde.Cluster, :set_members, [TestSup, sup_members])
+      end
+
+    [nodes: nodes]
+  end
+
+  test "a heal after a netsplit should ensure the process keeps running", %{
+    nodes: [n1, n2] = nodes
+  } do
+    id = "process"
+    Schism.heal([n1, n2])
+
+    # given two nodes
+    assert {:ok, pid} = rpc(n1, Worker, :start, [id])
+    # and a process
+    assert :ok = Worker.set_state(pid, "state")
+
+    current_node = node(pid)
+
+    other_node =
+      case current_node do
+        ^n1 -> n2
+        ^n2 -> n1
+      end
+
+    assert current_node != other_node
+
+    await_replication(nodes, other_node, id)
+
+    # when a partition is introduced
+    Schism.partition([n1])
+
+    new_pid = await_process_on_node(other_node, id)
+
+    # a new process with the same id should be started on the other node
+    assert new_pid != pid
+    assert node(new_pid) == other_node
+
+    # when the netsplit is healed
+    Schism.heal([n1, n2])
+
+    # the old process should be dead
+    :ok = await_dead(pid)
+
+    # and only a single process should remain
+    assert MapSet.new([true, false]) == MapSet.new([process_alive?(pid), process_alive?(new_pid)])
+  end
+
+  defp await_replication(nodes, target, id) do
+    for n <- nodes do
+      send({TestSup.Crdt, n}, :sync)
+      send({TestReg.Crdt, n}, :sync)
+    end
+
+    Process.sleep(200)
+
+    do_await_replication(target, id)
+  end
+
+  defp do_await_replication(target, id) do
+    pid = rpc(target, Horde.Registry, :whereis_name, [{TestReg, id}])
+
+    case pid do
+      pid when is_pid(pid) ->
+        pid
+
+      x ->
+        Process.sleep(200)
+        do_await_replication(target, id)
+    end
+  end
+
+  defp await_process_on_node(target, id) do
+    pid = rpc(target, Horde.Registry, :whereis_name, [{TestReg, id}])
+
+    case pid do
+      pid when is_pid(pid) ->
+        case node(pid) do
+          ^target ->
+            pid
+
+          _ ->
+            nodes = rpc(target, Node, :list, [])
+
+            Logger.info(
+              "found #{inspect(pid)} on node: #{inspect(node(pid))}, target #{inspect(node)}, nodes: #{
+                inspect(nodes)
+              }"
+            )
+
+            Process.sleep(200)
+            await_process_on_node(target, id)
+        end
+
+      _ ->
+        Logger.info("didn't find pid")
+        Process.sleep(200)
+        await_process_on_node(target, id)
+    end
+  end
+
+  defp rpc(n, m, f, a) do
+    :rpc.block_call(n, m, f, a)
+  end
+
+  defp await_dead(pid) do
+    case process_alive?(pid) do
+      false ->
+        :ok
+
+      true ->
+        Process.sleep(200)
+        await_dead(pid)
+    end
+  end
+
+  defp process_alive?(pid) do
+    rpc(node(pid), Process, :alive?, [pid])
+  end
+end

--- a/test/support/worker.ex
+++ b/test/support/worker.ex
@@ -1,0 +1,59 @@
+defmodule Worker do
+  require Logger
+
+  defstruct name: "",
+            state: ""
+
+  def state(name) do
+    GenServer.call(via_tuple(name), :state)
+  end
+
+  def set_state(pid, state) when is_pid(pid) do
+    GenServer.call(pid, {:set_state, state})
+  end
+
+  def set_state(name, state) do
+    GenServer.call(via_tuple(name), {:set_state, state})
+  end
+
+  def start(name) do
+    Horde.Supervisor.start_child(
+      TestSup,
+      child_spec(name: name)
+    )
+  end
+
+  def via_tuple(name) do
+    {:via, Horde.Registry, {TestReg, name}}
+  end
+
+  def start_link(name) do
+    GenServer.start_link(__MODULE__, name, name: via_tuple(name))
+  end
+
+  def init(name) do
+    Logger.info("Starting worker on #{inspect(Node.self())}")
+    {:ok, %__MODULE__{name: name}, {:continue, :started}}
+  end
+
+  def handle_continue(:started, state) do
+    Logger.info("Started worker on #{inspect(Node.self())}")
+    {:noreply, state}
+  end
+
+  def handle_call({:set_state, value}, _from, state) do
+    {:reply, :ok, %{state | state: value}}
+  end
+
+  def handle_call(:state, _from, state) do
+    {:reply, {:ok, state.state}, state}
+  end
+
+  defp child_spec(name: name) do
+    %{
+      id: String.to_atom("#{__MODULE__}_#{name}"),
+      start: {__MODULE__, :start_link, [name]},
+      shutdown: 10_000
+    }
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,6 +1,6 @@
 # Disable until we can get this working on CircleCI
-# :ok = LocalCluster.start()
+:ok = LocalCluster.start()
 
-# Application.ensure_all_started(:horde)
+Application.ensure_all_started(:horde)
 
 ExUnit.start()

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,5 @@
 # Disable until we can get this working on CircleCI
+{_, 0} = System.cmd("epmd", ["-daemon"])
 :ok = LocalCluster.start()
 
 Application.ensure_all_started(:horde)


### PR DESCRIPTION
As we spoke of on Slack.

I get this to fail _very_ sporadically locally. And there's also some weird output when the process starts, which makes it looks like it's initially starting twice on the same node.

```
12:28:09.927 [info]  Starting worker on :"cluster-3291@127.0.0.1"
12:28:09.927 [info]  Starting worker on :"cluster-3291@127.0.0.1"
12:28:09.927 [info]  Started worker on :"cluster-3291@127.0.0.1"
12:28:09.927 [info]  Started worker on :"cluster-3291@127.0.0.1"
```