### PR TITLE
Revert delta crdt options field naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Added guides for handling clustering, process state handoff (during deploys), and special considerations for eventual consistency to the [documentation](https://hexdocs.pm/horde).
 - `Horde.Supervisor` now uses libring to distribute processes over nodes. [#130](https://github.com/derekkraan/horde/pull/130)
 - `Horde.Supervisor` publishes metrics with `:telemetry` (`[:horde, :supervisor, :supervised_process_count]`). [#132](https://github.com/derekkraan/horde/pull/132)
-- `Horde.Supervisor` and `Horde.Registry` now support option `delta_crdt`, which you can use to tune your cluster. Also updated to the most recent DeltaCRDT. [#100](https://github.com/derekkraan/horde/pull/100)
+- `Horde.Supervisor` and `Horde.Registry` now support option `delta_crdt_options`, which you can use to tune your cluster. Also updated to the most recent DeltaCRDT. [#100](https://github.com/derekkraan/horde/pull/100)
 
 ## 0.6.0
 - `Horde.Supervisor` now behaves more like `DynamicSupervisor`. [#122](https://github.com/derekkraan/horde/pull/122)

--- a/guides/getting_started.md
+++ b/guides/getting_started.md
@@ -44,7 +44,7 @@ end
 This is also where you can set additional options for Horde.Supervisor:
 - `:members`, a list of members (if your cluster will have static membership)
 - `:distribution_strategy`, the distribution strategy (`Horde.UniformDistribution` is default)
-- `:delta_crdt`, for tuning the delta CRDT that underpins Horde
+- `:delta_crdt_options`, for tuning the delta CRDT that underpins Horde
 
 See the documentation for `Horde.Supervisor` for more information.
 
@@ -72,7 +72,7 @@ end
 
 There are also some additional options for Horde.Registry:
 - `:members`, a list of members (if your cluster will have static membership)
-- `:delta_crdt`, for tuning the delta CRDT that underpins Horde
+- `:delta_crdt_options`, for tuning the delta CRDT that underpins Horde
 
 See the documentation for `Horde.Registry` for more information.
 

--- a/lib/horde/registry.ex
+++ b/lib/horde/registry.ex
@@ -38,7 +38,7 @@ defmodule Horde.Registry do
   @type option ::
           {:keys, :unique}
           | {:name, atom()}
-          | {:delta_crdt, [DeltaCrdt.crdt_option()]}
+          | {:delta_crdt_options, [DeltaCrdt.crdt_option()]}
           | {:members, [Horde.Cluster.member()]}
 
   @callback init(options :: Keyword.t()) :: {:ok, options :: Keyword.t()}
@@ -94,7 +94,7 @@ defmodule Horde.Registry do
       :keys,
       :distribution_strategy,
       :members,
-      :delta_crdt
+      :delta_crdt_options
     ]
 
     {sup_options, start_options} = Keyword.split(options, keys)
@@ -123,7 +123,7 @@ defmodule Horde.Registry do
     listeners = Keyword.get(options, :listeners, [])
     meta = Keyword.get(options, :meta, nil)
     members = Keyword.get(options, :members, [])
-    delta_crdt = Keyword.get(options, :delta_crdt, [])
+    delta_crdt_options = Keyword.get(options, :delta_crdt_options, [])
 
     distribution_strategy =
       Keyword.get(
@@ -138,7 +138,7 @@ defmodule Horde.Registry do
       keys: keys,
       distribution_strategy: distribution_strategy,
       members: members,
-      delta_crdt_config: delta_crdt_config(delta_crdt)
+      delta_crdt_options: delta_crdt_options(delta_crdt_options)
     }
 
     {:ok, flags}
@@ -150,9 +150,9 @@ defmodule Horde.Registry do
         children = [
           {DeltaCrdt,
            [
-             sync_interval: flags.delta_crdt_config.sync_interval,
-             max_sync_size: flags.delta_crdt_config.max_sync_size,
-             shutdown: flags.delta_crdt_config.shutdown,
+             sync_interval: flags.delta_crdt_options.sync_interval,
+             max_sync_size: flags.delta_crdt_options.max_sync_size,
+             shutdown: flags.delta_crdt_options.shutdown,
              crdt: DeltaCrdt.AWLWWMap,
              on_diffs: &on_diffs(&1, name),
              name: crdt_name(name)
@@ -413,7 +413,7 @@ defmodule Horde.Registry do
     end
   end
 
-  defp delta_crdt_config(options) do
+  defp delta_crdt_options(options) do
     %{
       sync_interval: Keyword.get(options, :sync_interval, 300),
       max_sync_size: Keyword.get(options, :max_sync_size, :infinite),

--- a/lib/horde/supervisor.ex
+++ b/lib/horde/supervisor.ex
@@ -62,7 +62,7 @@ defmodule Horde.Supervisor do
           | {:distribution_strategy, Horde.DistributionStrategy.t()}
           | {:shutdown, integer()}
           | {:members, [Horde.Cluster.member()]}
-          | {:delta_crdt, [DeltaCrdt.crdt_option()]}
+          | {:delta_crdt_options, [DeltaCrdt.crdt_option()]}
 
   @callback init(options()) :: {:ok, options()}
   @callback child_spec(options :: options()) :: Supervisor.child_spec()
@@ -118,7 +118,7 @@ defmodule Horde.Supervisor do
       :strategy,
       :distribution_strategy,
       :members,
-      :delta_crdt
+      :delta_crdt_options
     ]
 
     {sup_options, start_options} = Keyword.split(options, keys)
@@ -144,7 +144,7 @@ defmodule Horde.Supervisor do
     max_children = Keyword.get(options, :max_children, :infinity)
     extra_arguments = Keyword.get(options, :extra_arguments, [])
     members = Keyword.get(options, :members, [])
-    delta_crdt = Keyword.get(options, :delta_crdt, [])
+    delta_crdt_options = Keyword.get(options, :delta_crdt_options, [])
 
     distribution_strategy =
       Keyword.get(
@@ -161,7 +161,7 @@ defmodule Horde.Supervisor do
       extra_arguments: extra_arguments,
       distribution_strategy: distribution_strategy,
       members: members,
-      delta_crdt_config: delta_crdt_config(delta_crdt)
+      delta_crdt_options: delta_crdt_options(delta_crdt_options)
     }
 
     {:ok, flags}
@@ -173,9 +173,9 @@ defmodule Horde.Supervisor do
         children = [
           {DeltaCrdt,
            [
-             sync_interval: flags.delta_crdt_config.sync_interval,
-             max_sync_size: flags.delta_crdt_config.max_sync_size,
-             shutdown: flags.delta_crdt_config.shutdown,
+             sync_interval: flags.delta_crdt_options.sync_interval,
+             max_sync_size: flags.delta_crdt_options.max_sync_size,
+             shutdown: flags.delta_crdt_options.shutdown,
              crdt: DeltaCrdt.AWLWWMap,
              on_diffs: &on_diffs(&1, name),
              name: crdt_name(name)
@@ -272,7 +272,7 @@ defmodule Horde.Supervisor do
 
   defp call(supervisor, msg), do: GenServer.call(supervisor, msg, :infinity)
 
-  defp delta_crdt_config(options) do
+  defp delta_crdt_options(options) do
     %{
       sync_interval: Keyword.get(options, :sync_interval, 300),
       max_sync_size: Keyword.get(options, :max_sync_size, :infinite),

--- a/test/cluster_test.exs
+++ b/test/cluster_test.exs
@@ -8,7 +8,7 @@ defmodule ClusterTest do
           name: :reg4,
           keys: :unique,
           members: [:reg4, :reg5],
-          delta_crdt: [sync_interval: 10]
+          delta_crdt_options: [sync_interval: 10]
         )
 
       {:ok, _} =
@@ -16,7 +16,7 @@ defmodule ClusterTest do
           name: :reg5,
           keys: :unique,
           members: [:reg4, :reg5],
-          delta_crdt: [sync_interval: 10]
+          delta_crdt_options: [sync_interval: 10]
         )
 
       members = Horde.Cluster.members(:reg4)
@@ -29,7 +29,7 @@ defmodule ClusterTest do
           name: :sup4,
           strategy: :one_for_one,
           members: [:sup4, :sup5],
-          delta_crdt: [sync_interval: 10]
+          delta_crdt_options: [sync_interval: 10]
         )
 
       {:ok, _} =
@@ -37,7 +37,7 @@ defmodule ClusterTest do
           name: :sup5,
           strategy: :one_for_one,
           members: [:sup4, :sup5],
-          delta_crdt: [sync_interval: 10]
+          delta_crdt_options: [sync_interval: 10]
         )
 
       members = Horde.Cluster.members(:sup4)
@@ -51,7 +51,7 @@ defmodule ClusterTest do
         Horde.Registry.start_link(
           name: :reg0,
           keys: :unique,
-          delta_crdt: [sync_interval: 10]
+          delta_crdt_options: [sync_interval: 10]
         )
 
       assert :ok = Horde.Cluster.set_members(:reg0, [:reg00, :reg0])
@@ -65,7 +65,7 @@ defmodule ClusterTest do
         Horde.Supervisor.start_link(
           name: :sup0,
           strategy: :one_for_one,
-          delta_crdt: [sync_interval: 10]
+          delta_crdt_options: [sync_interval: 10]
         )
 
       assert :ok = Horde.Cluster.set_members(:sup0, [:sup00, :sup0])
@@ -81,14 +81,14 @@ defmodule ClusterTest do
         Horde.Registry.start_link(
           name: :reg1,
           keys: :unique,
-          delta_crdt: [sync_interval: 10]
+          delta_crdt_options: [sync_interval: 10]
         )
 
       {:ok, _reg2} =
         Horde.Registry.start_link(
           name: :reg2,
           keys: :unique,
-          delta_crdt: [sync_interval: 10]
+          delta_crdt_options: [sync_interval: 10]
         )
 
       assert :ok = Horde.Cluster.set_members(:reg1, [:reg1, :reg2])
@@ -99,14 +99,14 @@ defmodule ClusterTest do
         Horde.Supervisor.start_link(
           name: :sup1,
           strategy: :one_for_one,
-          delta_crdt: [sync_interval: 10]
+          delta_crdt_options: [sync_interval: 10]
         )
 
       {:ok, _} =
         Horde.Supervisor.start_link(
           name: :sup2,
           strategy: :one_for_one,
-          delta_crdt: [sync_interval: 10]
+          delta_crdt_options: [sync_interval: 10]
         )
 
       assert :ok = Horde.Cluster.set_members(:sup1, [:sup1, :sup2])
@@ -117,7 +117,7 @@ defmodule ClusterTest do
         Horde.Registry.start_link(
           name: :reg3,
           keys: :unique,
-          delta_crdt: [sync_interval: 10]
+          delta_crdt_options: [sync_interval: 10]
         )
 
       assert :ok = Horde.Cluster.set_members(:reg3, [:reg3, :doesnt_exist], 100)
@@ -128,7 +128,7 @@ defmodule ClusterTest do
         Horde.Supervisor.start_link(
           name: :sup3,
           strategy: :one_for_one,
-          delta_crdt: [sync_interval: 10]
+          delta_crdt_options: [sync_interval: 10]
         )
 
       assert :ok = Horde.Cluster.set_members(:sup3, [:sup3, :doesnt_exist], 100)
@@ -139,14 +139,14 @@ defmodule ClusterTest do
         Horde.Supervisor.start_link(
           name: :sup6,
           strategy: :one_for_one,
-          delta_crdt: [sync_interval: 10]
+          delta_crdt_options: [sync_interval: 10]
         )
 
       {:ok, _} =
         Horde.Supervisor.start_link(
           name: :sup7,
           strategy: :one_for_one,
-          delta_crdt: [sync_interval: 10]
+          delta_crdt_options: [sync_interval: 10]
         )
 
       assert :ok = Horde.Cluster.set_members(:sup6, [:sup6, :sup7])
@@ -166,14 +166,14 @@ defmodule ClusterTest do
         Horde.Registry.start_link(
           name: :reg6,
           keys: :unique,
-          delta_crdt: [sync_interval: 10]
+          delta_crdt_options: [sync_interval: 10]
         )
 
       {:ok, _} =
         Horde.Registry.start_link(
           name: :reg7,
           keys: :unique,
-          delta_crdt: [sync_interval: 10]
+          delta_crdt_options: [sync_interval: 10]
         )
 
       assert :ok = Horde.Cluster.set_members(:reg6, [:reg6, :reg7])

--- a/test/registry_test.exs
+++ b/test/registry_test.exs
@@ -28,7 +28,7 @@ defmodule RegistryTest do
         Horde.Registry.start_link(
           name: :horde_not_unique,
           keys: :duplicate,
-          delta_crdt: [sync_interval: 20]
+          delta_crdt_options: [sync_interval: 20]
         )
       end
     end
@@ -310,14 +310,14 @@ defmodule RegistryTest do
         Horde.Registry.start_link(
           name: horde1,
           keys: :unique,
-          delta_crdt: [sync_interval: 20]
+          delta_crdt_options: [sync_interval: 20]
         )
 
       {:ok, _} =
         Horde.Registry.start_link(
           name: horde2,
           keys: :unique,
-          delta_crdt: [sync_interval: 20]
+          delta_crdt_options: [sync_interval: 20]
         )
 
       Horde.Cluster.set_members(horde1, [horde1, horde2])
@@ -484,7 +484,7 @@ defmodule RegistryTest do
         Horde.Registry.start_link(
           name: :match_horde,
           keys: :unique,
-          delta_crdt: [sync_interval: 20]
+          delta_crdt_options: [sync_interval: 20]
         )
 
       Horde.Registry.register(:match_horde, "foo", "foo")
@@ -513,7 +513,7 @@ defmodule RegistryTest do
         Horde.Registry.start_link(
           name: :update_value_horde,
           keys: :unique,
-          delta_crdt: [sync_interval: 20]
+          delta_crdt_options: [sync_interval: 20]
         )
 
       Horde.Registry.register(:update_value_horde, "foo", "foo")
@@ -533,7 +533,7 @@ defmodule RegistryTest do
         Horde.Registry.start_link(
           name: :update_value_horde2,
           keys: :unique,
-          delta_crdt: [sync_interval: 20]
+          delta_crdt_options: [sync_interval: 20]
         )
 
       Task.start_link(fn ->
@@ -556,7 +556,7 @@ defmodule RegistryTest do
         Horde.Registry.start_link(
           name: horde,
           keys: :unique,
-          delta_crdt: [sync_interval: 20]
+          delta_crdt_options: [sync_interval: 20]
         )
 
       Horde.Registry.register(horde, :carmen, "foo")
@@ -571,7 +571,7 @@ defmodule RegistryTest do
         Horde.Registry.start_link(
           name: horde,
           keys: :unique,
-          delta_crdt: [sync_interval: 20]
+          delta_crdt_options: [sync_interval: 20]
         )
 
       Horde.Registry.register(horde, :carmen, "bar")
@@ -589,7 +589,7 @@ defmodule RegistryTest do
         Horde.Registry.start_link(
           name: horde,
           keys: :unique,
-          delta_crdt: [sync_interval: 20]
+          delta_crdt_options: [sync_interval: 20]
         )
 
       Horde.Registry.register(horde, :carmen, "carmen")
@@ -606,7 +606,7 @@ defmodule RegistryTest do
         Horde.Registry.start_link(
           name: horde,
           keys: :unique,
-          delta_crdt: [sync_interval: 20]
+          delta_crdt_options: [sync_interval: 20]
         )
 
       spawn(fn ->
@@ -628,7 +628,7 @@ defmodule RegistryTest do
         Horde.Registry.start_link(
           name: horde,
           keys: :unique,
-          delta_crdt: [sync_interval: 20]
+          delta_crdt_options: [sync_interval: 20]
         )
 
       spawn(fn ->
@@ -651,7 +651,7 @@ defmodule RegistryTest do
           name: registry,
           keys: :unique,
           meta: [meta_key: :meta_value],
-          delta_crdt: [sync_interval: 20]
+          delta_crdt_options: [sync_interval: 20]
         )
 
       assert {:ok, :meta_value} = Horde.Registry.meta(registry, :meta_key)
@@ -664,7 +664,7 @@ defmodule RegistryTest do
         Horde.Registry.start_link(
           name: registry,
           keys: :unique,
-          delta_crdt: [sync_interval: 20]
+          delta_crdt_options: [sync_interval: 20]
         )
 
       :ok = Horde.Registry.put_meta(registry, :custom_key, "custom_value")
@@ -679,7 +679,7 @@ defmodule RegistryTest do
         Horde.Registry.start_link(
           name: registry,
           keys: :unique,
-          delta_crdt: [sync_interval: 20]
+          delta_crdt_options: [sync_interval: 20]
         )
 
       :ok = Horde.Registry.put_meta(registry, :custom_key, "custom_value")
@@ -695,14 +695,14 @@ defmodule RegistryTest do
         Horde.Registry.start_link(
           name: r1,
           keys: :unique,
-          delta_crdt: [sync_interval: 20]
+          delta_crdt_options: [sync_interval: 20]
         )
 
       {:ok, _horde} =
         Horde.Registry.start_link(
           name: r2,
           keys: :unique,
-          delta_crdt: [sync_interval: 20]
+          delta_crdt_options: [sync_interval: 20]
         )
 
       Horde.Cluster.set_members(r1, [r1, r2])
@@ -720,7 +720,7 @@ defmodule RegistryTest do
         Horde.Registry.start_link(
           name: registry,
           keys: :unique,
-          delta_crdt: [sync_interval: 20]
+          delta_crdt_options: [sync_interval: 20]
         )
 
       %{pid: pid} =
@@ -748,14 +748,14 @@ defmodule RegistryTest do
           name: reg1,
           keys: :unique,
           members: [reg1, reg2],
-          delta_crdt: [sync_interval: 20]
+          delta_crdt_options: [sync_interval: 20]
         )
 
       {:ok, _} =
         Horde.Registry.start_link(
           name: reg2,
           keys: :unique,
-          delta_crdt: [sync_interval: 20]
+          delta_crdt_options: [sync_interval: 20]
         )
 
       %{pid: pid} =
@@ -859,7 +859,7 @@ defmodule RegistryTest do
     horde = :"h#{-:erlang.monotonic_time()}"
 
     {:ok, _pid} =
-      Horde.Registry.start_link([name: horde, delta_crdt: [sync_interval: 20]] ++ opts)
+      Horde.Registry.start_link([name: horde, delta_crdt_options: [sync_interval: 20]] ++ opts)
 
     horde
   end

--- a/test/supervisor_test.exs
+++ b/test/supervisor_test.exs
@@ -11,21 +11,21 @@ defmodule SupervisorTest do
       Horde.Supervisor.start_link(
         name: n1,
         strategy: :one_for_one,
-        delta_crdt: [sync_interval: 20]
+        delta_crdt_options: [sync_interval: 20]
       )
 
     {:ok, _} =
       Horde.Supervisor.start_link(
         name: n2,
         strategy: :one_for_one,
-        delta_crdt: [sync_interval: 20]
+        delta_crdt_options: [sync_interval: 20]
       )
 
     {:ok, _} =
       Horde.Supervisor.start_link(
         name: n3,
         strategy: :one_for_one,
-        delta_crdt: [sync_interval: 20]
+        delta_crdt_options: [sync_interval: 20]
       )
 
     Horde.Cluster.set_members(n1, [n1, n2, n3])
@@ -282,14 +282,14 @@ defmodule SupervisorTest do
         Horde.Supervisor.start_link(
           name: :horde_1_graceful,
           strategy: :one_for_one,
-          delta_crdt: [sync_interval: 20]
+          delta_crdt_options: [sync_interval: 20]
         )
 
       {:ok, _} =
         Horde.Supervisor.start_link(
           name: :horde_2_graceful,
           strategy: :one_for_one,
-          delta_crdt: [sync_interval: 20]
+          delta_crdt_options: [sync_interval: 20]
         )
 
       defmodule TerminationDelay do
@@ -355,7 +355,7 @@ defmodule SupervisorTest do
         Horde.Supervisor.start_link(
           name: :horde_transient,
           strategy: :one_for_one,
-          delta_crdt: [sync_interval: 20]
+          delta_crdt_options: [sync_interval: 20]
         )
 
       Horde.Supervisor.start_child(:horde_transient, child_spec)
@@ -374,7 +374,7 @@ defmodule SupervisorTest do
         Horde.Supervisor.start_link(
           name: :horde_transient,
           strategy: :one_for_one,
-          delta_crdt: [sync_interval: 20]
+          delta_crdt_options: [sync_interval: 20]
         )
 
       Horde.Supervisor.start_child(:horde_transient, child_spec)
@@ -393,7 +393,7 @@ defmodule SupervisorTest do
         Horde.Supervisor.start_link(
           name: :horde_transient,
           strategy: :one_for_one,
-          delta_crdt: [sync_interval: 20]
+          delta_crdt_options: [sync_interval: 20]
         )
 
       Horde.Supervisor.start_child(:horde_transient, child_spec)
@@ -447,7 +447,7 @@ defmodule SupervisorTest do
         strategy: :one_for_one,
         distribution_strategy: Horde.UniformQuorumDistribution,
         members: [:horde_quorum_1, :horde_quorum_2, :horde_quorum_3],
-        delta_crdt: [sync_interval: 20]
+        delta_crdt_options: [sync_interval: 20]
       )
 
     catch_exit(Horde.Supervisor.wait_for_quorum(:horde_quorum_1, 100))
@@ -458,7 +458,7 @@ defmodule SupervisorTest do
         strategy: :one_for_one,
         distribution_strategy: Horde.UniformQuorumDistribution,
         members: [:horde_quorum_1, :horde_quorum_2, :horde_quorum_3],
-        delta_crdt: [sync_interval: 20]
+        delta_crdt_options: [sync_interval: 20]
       )
 
     assert :ok == Horde.Supervisor.wait_for_quorum(:horde_quorum_1, 1000)


### PR DESCRIPTION
My fault, I didn't remember when I renamed `delta_crdt_options` to `delta_crdt` in my previous pull request, and it wasn't my intention.