### PR TITLE
intermittently failing netsplit/name conflict test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,4 @@ jobs:
       - run: mix deps.get
       - run: mix compile --warnings-as-errors
       - run: mix format --check-formatted
-      - run:
-          command: |
-            epmd -daemon
-            mix test
+      - run: mix test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,4 +18,7 @@ jobs:
       - run: mix deps.get
       - run: mix compile --warnings-as-errors
       - run: mix format --check-formatted
-      - run: mix test
+      - run:
+          command: |
+            epmd -daemon
+            mix test

--- a/test/netsplit_test.exs
+++ b/test/netsplit_test.exs
@@ -61,13 +61,13 @@ defmodule NetsplitTest do
       ])
     end)
 
+    # Wait for supervisor and registry in all nodes
+    Process.sleep(sleep_millis)
+
     Enum.each(nodes, fn node ->
       assert MySupervisor.alive?(node)
       assert MyRegistry.alive?(node)
     end)
-
-    # Wait for supervisor and registry in all nodes
-    Process.sleep(sleep_millis)
 
     Schism.partition([node1, node2])
     Schism.partition([node3])
@@ -98,9 +98,9 @@ defmodule NetsplitTest do
     end)
 
     # Verify all nodes are able to see the same pid for that server
-    pid1 = MyCluster.whereis(node1, server_name)
-    pid2 = MyCluster.whereis(node2, server_name)
-    pid3 = MyCluster.whereis(node3, server_name)
+    pid1 = MyCluster.whereis_server(node1, server_name)
+    pid2 = MyCluster.whereis_server(node2, server_name)
+    pid3 = MyCluster.whereis_server(node3, server_name)
 
     assert is_pid(pid1)
     assert pid1 == pid2

--- a/test/netsplit_test.exs
+++ b/test/netsplit_test.exs
@@ -40,4 +40,71 @@ defmodule NetsplitTest do
     assert_receive {^other_node, :hello_echo_server}, 1100
     refute_receive {^n, :hello_echo_server}, 1100
   end
+
+  test "name conflict after healing netsplit" do
+    cluster_name = "cluster"
+    server_name = "server"
+    sleep_millis = 2000
+
+    [node1, node2, node3] = nodes = LocalCluster.start_nodes(cluster_name, 3)
+
+    Enum.each(nodes, fn node ->
+      assert :pong = Node.ping(node)
+    end)
+
+    # Start a test supervision tree in all three nodes
+    Enum.each(nodes, fn node ->
+      Node.spawn(node, LocalClusterHelper, :start, [
+        MySupervisionTree,
+        :start_link,
+        [[cluster: cluster_name, distribution: Horde.UniformQuorumDistribution, sync_interval: 5]]
+      ])
+    end)
+
+    Enum.each(nodes, fn node ->
+      assert MySupervisor.alive?(node)
+      assert MyRegistry.alive?(node)
+    end)
+
+    # Wait for supervisor and registry in all nodes
+    Process.sleep(sleep_millis)
+
+    Schism.partition([node1, node2])
+    Schism.partition([node3])
+
+    Process.sleep(sleep_millis)
+
+    Enum.each(nodes, fn node ->
+      assert MySupervisor.alive?(node)
+      assert MyRegistry.alive?(node)
+    end)
+
+    # Create a server with the same name in both partitions
+    {:ok, pid1} = MyCluster.start_server(node1, server_name)
+    {:ok, pid2} = MyCluster.start_server(node3, server_name)
+
+    assert Enum.member?([node1, node2], node(pid1))
+    assert node3 == node(pid2)
+
+    Process.sleep(sleep_millis)
+
+    # Heal the cluster
+    Schism.heal(nodes)
+    Process.sleep(sleep_millis)
+
+    Enum.each(nodes, fn node ->
+      assert MySupervisor.alive?(node)
+      assert MyRegistry.alive?(node)
+    end)
+
+    # Verify all nodes are able to see the same pid for that server
+    pid1 = MyCluster.whereis(node1, server_name)
+    pid2 = MyCluster.whereis(node2, server_name)
+    pid3 = MyCluster.whereis(node3, server_name)
+
+    assert is_pid(pid1)
+    assert pid1 == pid2
+    assert pid1 == pid3
+    assert pid2 == pid3
+  end
 end

--- a/test/support/my_supervision_tree.ex
+++ b/test/support/my_supervision_tree.ex
@@ -1,0 +1,204 @@
+defmodule MySupervisionTree do
+  use Supervisor
+
+  def start_link([cluster: _, distribution: _, sync_interval: _] = args) do
+    Supervisor.start_link(__MODULE__, args, name: __MODULE__)
+  end
+
+  @impl true
+  def init(args) do
+    children = [
+      {MyRegistry, args},
+      {MySupervisor, args},
+      {MyNodeListener, args}
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+end
+
+defmodule MyCluster do
+  def set_members(name, cluster) do
+    members = members(name, cluster)
+    :ok = Horde.Cluster.set_members(name, members)
+  end
+
+  def members(name, cluster) do
+    [Node.self() | Node.list()]
+    |> Enum.filter(fn node ->
+      String.contains?("#{node}", cluster)
+    end)
+    |> Enum.map(fn node -> {name, node} end)
+  end
+
+  def start_server(node, name) do
+    :rpc.call(node, MyCluster, :start_server, [name])
+  end
+
+  def start_server(name) do
+    Horde.DynamicSupervisor.start_child(MySupervisor, {MyServer, name})
+  end
+
+  def whereis(name) do
+    MyServer.whereis(name)
+  end
+
+  def whereis(node, name) do
+    :rpc.call(node, MyCluster, :whereis, [name])
+  end
+end
+
+defmodule MyRegistry do
+  use Horde.Registry
+
+  def start_link(args) do
+    args =
+      Keyword.merge(args,
+        keys: :unique,
+        delta_crdt_options: [
+          sync_interval: args[:sync_interval]
+        ]
+      )
+
+    Horde.Registry.start_link(__MODULE__, args, name: __MODULE__)
+  end
+
+  def init(args) do
+    members = MyCluster.members(__MODULE__, args[:cluster])
+    args = Keyword.merge(args, members: members)
+    Horde.Registry.init(args)
+  end
+
+  def via_tuple(spec) do
+    {:via, Horde.Registry, {__MODULE__, spec}}
+  end
+
+  def whereis(spec) do
+    case Horde.Registry.lookup(spec) do
+      [{pid, _data}] ->
+        pid
+
+      [] ->
+        :not_found
+    end
+  end
+
+  def pid() do
+    Process.whereis(__MODULE__)
+  end
+
+  def alive?(node) do
+    :rpc.call(node, Process, :alive?, [])
+  end
+
+  def alive?() do
+    case pid() do
+      pid when is_pid(pid) ->
+        Process.alive?(pid)
+
+      nil ->
+        false
+    end
+  end
+end
+
+defmodule MySupervisor do
+  use Horde.DynamicSupervisor
+
+  def start_link(args) do
+    args =
+      Keyword.merge(args,
+        restart: 5000,
+        strategy: :one_for_one,
+        delta_crdt_options: [
+          sync_interval: args[:sync_interval]
+        ],
+        distribution_strategy: args[:distribution]
+      )
+
+    Horde.DynamicSupervisor.start_link(__MODULE__, args, name: __MODULE__)
+  end
+
+  def init(args) do
+    members = MyCluster.members(__MODULE__, args[:cluster])
+    args = Keyword.merge(args, members: members)
+
+    Horde.DynamicSupervisor.init(args)
+  end
+
+  def pid() do
+    Process.whereis(__MODULE__)
+  end
+
+  def alive?(node) do
+    :rpc.call(node, Process, :alive?, [])
+  end
+
+  def alive?() do
+    case pid() do
+      pid when is_pid(pid) ->
+        Process.alive?(pid)
+
+      nil ->
+        false
+    end
+  end
+end
+
+defmodule MyNodeListener do
+  use GenServer
+
+  def start_link(args) do
+    args = Keyword.take(args, [:cluster])
+    args = Keyword.merge(args, name: __MODULE__)
+    GenServer.start_link(__MODULE__, args, name: args[:name])
+  end
+
+  def init(args) do
+    :net_kernel.monitor_nodes(true, node_type: :visible)
+    {:ok, args}
+  end
+
+  def handle_info({:nodeup, _node, _node_type}, state) do
+    cluster_name = state[:cluster]
+    MyCluster.set_members(MyRegistry, cluster_name)
+    MyCluster.set_members(MySupervisor, cluster_name)
+    {:noreply, state}
+  end
+
+  def handle_info({:nodedown, _node, _node_type}, state) do
+    cluster_name = state[:cluster]
+    MyCluster.set_members(MyRegistry, cluster_name)
+    MyCluster.set_members(MySupervisor, cluster_name)
+    {:noreply, state}
+  end
+end
+
+defmodule MyServer do
+  use GenServer
+
+  def start_link(name) do
+    spec = via_tuple(name)
+    GenServer.start_link(__MODULE__, [name], name: spec)
+  end
+
+  def child_spec(name) do
+    %{
+      id: name,
+      restart: :transient,
+      start: {__MODULE__, :start_link, [name]}
+    }
+  end
+
+  def init(name) do
+    {:ok, name}
+  end
+
+  defp via_tuple(name) do
+    MyRegistry.via_tuple({__MODULE__, name})
+  end
+
+  def whereis(name) do
+    MyRegistry.whereis(via_tuple(name))
+  end
+end

--- a/test/support/my_supervision_tree.ex
+++ b/test/support/my_supervision_tree.ex
@@ -226,10 +226,4 @@ defmodule MyServer do
     IO.inspect(conflict: name, looser: {self(), node(self())}, winner: {winner, node(winner)})
     {:stop, :shutdown, state}
   end
-
-  @impl GenServer
-  def terminate(reason, name) do
-    IO.inspect(terminate: name, reason: reason, pid: self(), node: Node.self())
-    :ok
-  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,6 +1,6 @@
 # Disable until we can get this working on CircleCI
-# :ok = LocalCluster.start()
+:ok = LocalCluster.start()
 
-# Application.ensure_all_started(:horde)
+Application.ensure_all_started(:horde)
 
 ExUnit.start()


### PR DESCRIPTION
This PR does not fix anything. It adds a net split/name conflict test case that, when run in a loop, either:

a. passes ok, without any errors.
b. passes, but produces a bunch of errors such as:

```
23:12:46.234 [error] GenServer MySupervisor terminating
** (stop) exited in: GenServer.stop(MySupervisor.ProcessesSupervisor, :normal, :infinity)
    ** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started
    (elixir) lib/gen_server.ex:967: GenServer.stop/3
    (horde) lib/horde/dynamic_supervisor_impl.ex:588: Horde.DynamicSupervisorImpl.shut_down_all_processes/1
    (horde) lib/horde/dynamic_supervisor_impl.ex:568: Horde.DynamicSupervisorImpl.set_members/2
    (horde) lib/horde/dynamic_supervisor_impl.ex:117: Horde.DynamicSupervisorImpl.handle_call/3
    (stdlib) gen_server.erl:661: :gen_server.try_handle_call/4
    (stdlib) gen_server.erl:690: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Last message (from MyNodeListener): {:set_members, [{MySupervisor, :"cluster3@127.0.0.1"}, {MySupervisor, :"cluster1@127.0.0.1"}, {MySupervisor, :"cluster2@127.0.0.1"}]}
State: %Horde.DynamicSupervisorImpl{distribution_strategy: Horde.UniformQuorumDistribution, local_process_count: 1, members: %{{MySupervisor, :"cluster1@127.0.0.1"} => 1, {MySupervisor, :"cluster3@127.0.0.1"} => 1}, members_info: %{{MySupervisor, :"cluster1@127.0.0.1"} => %Horde.DynamicSupervisor.Member{name: {MySupervisor, :"cluster1@127.0.0.1"}, status: :uninitialized}, {MySupervisor, :"cluster3@127.0.0.1"} => %Horde.DynamicSupervisor.Member{name: {MySupervisor, :"cluster3@127.0.0.1"}, status: :alive}}, name: MySupervisor, name_to_supervisor_ref: %{{MySupervisor, :"cluster3@127.0.0.1"} => #Reference<0.3949222649.1386741761.258212>}, process_pid_to_id: %{#PID<0.255.0> => 5259026643766536929103073606755727837}, processes_by_id: %{5259026643766536929103073606755727837 => {{MySupervisor, :"cluster3@127.0.0.1"}, %{id: 5259026643766536929103073606755727837, restart: :transient, start: {MyServer, :start_link, ["server"]}}, #PID<0.255.0>}}, shutting_down: false, supervisor_options: [name: MySupervisor, root_name: MySupervisor, init_module: MySupervisor, strategy: :one_for_one, intensity: 3, period: 5, max_children: :infinity, extra_arguments: [], strategy: :one_for_one, distribution_strategy: Horde.UniformQuorumDistribution, members: [MySupervisor, {MySupervisor, :"cluster3@127.0.0.1"}, {MySupervisor, :"cluster1@127.0.0.1"}, {MySupervisor, :"cluster2@127.0.0.1"}]], supervisor_ref_to_name: %{#Reference<0.3949222649.1386741761.258212> => {MySupervisor, :"cluster3@127.0.0.1"}}, waiting_for_quorum: []}
```

c. fails. 

The test itself is not very elegant, since it does a few `Process.sleep/1` calls I am not very proud of. Also, it is highly possible my setup might be flawed somehow. I was not able to reproduce the errors I was originally chasing for. However, I hope this PR helps either to reveal a bug in Horde, or a bug in the test fixture itself.

Thanks in advance for the attention and time spent on this one!
Pedro. 
