### PR TITLE
Add :auto option for cluster membership

### DIFF
--- a/guides/libcluster.md
+++ b/guides/libcluster.md
@@ -2,7 +2,15 @@
 
 Horde doesn't provide functionality to set up your cluster, we recommend you use [`libcluster`](https://hexdocs.pm/libcluster/readme.html) for this purpose.
 
-There are two strategies you can use to integrate libcluster with Horde:
+There are three strategies you can use to integrate libcluster with Horde:
+
+## Automatic Cluster Membership
+
+When starting a `Horde.Registry` or `Horde.DynamicSupervisor`, setting the `members`
+option to have a value of `:auto` will automate membership management. In this
+mode, all visible nodes will be initially added to the cluster. In addition,
+any new nodes that become visible will be automatically added and any
+nodes that shut down will be automatically removed.
 
 ## Static Cluster Membership
 
@@ -34,7 +42,7 @@ This is the simplest approach. You tell Horde which members are supposed to be i
 
 ## Dynamic Cluster Membership
 
-If you will be adding and removing nodes from your cluster constantly, and don't want to repackage your application every time you do this, then you will need to perform a couple of extra steps.
+If you will be adding and removing nodes from your cluster constantly, and don't want to repackage your application every time you do this, then you will need to perform a couple of extra steps (assuming your needs cannot be met by the [`:auto` setting](#automatic-cluster-membership)).
 
 In this scenario, you will need to implement a [module-based Supervisor](https://hexdocs.pm/horde/Horde.DynamicSupervisor.html#module-module-based-supervisor)
 
@@ -124,3 +132,8 @@ defmodule NodeListener do
   end
 end
 ```
+
+Note that the funcionality provided in this example is essentially the same as
+the [`members: :auto` setting](#automatic-cluster-membership), however setting
+it up yourself allows greater flexability to modify it if `:auto` mode doesn't
+meet your requirements.

--- a/lib/horde/dynamic_supervisor_impl.ex
+++ b/lib/horde/dynamic_supervisor_impl.ex
@@ -59,7 +59,11 @@ defmodule Horde.DynamicSupervisorImpl do
   def handle_continue({:set_members, nil}, state), do: {:noreply, state}
 
   def handle_continue({:set_members, :auto}, state) do
-    Horde.NodeListener.initial_set(state.name)
+    state =
+      state.name
+      |> Horde.NodeListener.make_members()
+      |> set_members(state)
+
     {:noreply, state}
   end
 

--- a/lib/horde/dynamic_supervisor_impl.ex
+++ b/lib/horde/dynamic_supervisor_impl.ex
@@ -58,6 +58,11 @@ defmodule Horde.DynamicSupervisorImpl do
 
   def handle_continue({:set_members, nil}, state), do: {:noreply, state}
 
+  def handle_continue({:set_members, :auto}, state) do
+    Horde.NodeListener.initial_set(state.name)
+    {:noreply, state}
+  end
+
   def handle_continue({:set_members, members}, state) do
     {:noreply, set_members(members, state)}
   end

--- a/lib/horde/node_listener.ex
+++ b/lib/horde/node_listener.ex
@@ -1,0 +1,56 @@
+defmodule Horde.NodeListener do
+  @moduledoc """
+  A cluster membership manager.
+
+  Horde.NodeListener monitors nodes in BEAM's distribution system and
+  automatically adds and removes those marked as `visible` from the cluster it's
+  managing
+  """
+  use GenServer
+
+  # API
+
+  @spec start_link(atom()) :: GenServer.on_start()
+  def start_link(cluster),
+    do: GenServer.start_link(__MODULE__, cluster, name: listener_name(cluster))
+
+  @spec initial_set(atom()) :: :ok
+  def initial_set(cluster) do
+    GenServer.cast(listener_name(cluster), :initial_set)
+  end
+
+  # GenServer callbacks
+
+  def init(cluster) do
+    :net_kernel.monitor_nodes(true, node_type: :visible)
+    {:ok, cluster}
+  end
+
+  def handle_cast(:initial_set, cluster) do
+    set_members(cluster)
+    {:noreply, cluster}
+  end
+
+  def handle_info({:nodeup, _node, _node_type}, cluster) do
+    set_members(cluster)
+    {:noreply, cluster}
+  end
+
+  def handle_info({:nodedown, _node, _node_type}, cluster) do
+    set_members(cluster)
+    {:noreply, cluster}
+  end
+
+  def handle_info(_, cluster), do: {:noreply, cluster}
+
+  # Helper functions
+
+  defp listener_name(cluster), do: Module.concat(cluster, NodeListener)
+
+  defp set_members(cluster) do
+    members = Enum.map(nodes(), fn node -> {cluster, node} end)
+    :ok = Horde.Cluster.set_members(cluster, members)
+  end
+
+  defp nodes(), do: Node.list([:visible, :this])
+end

--- a/lib/horde/node_listener.ex
+++ b/lib/horde/node_listener.ex
@@ -14,10 +14,9 @@ defmodule Horde.NodeListener do
   def start_link(cluster),
     do: GenServer.start_link(__MODULE__, cluster, name: listener_name(cluster))
 
-  @spec initial_set(atom()) :: :ok
-  def initial_set(cluster) do
-    GenServer.cast(listener_name(cluster), :initial_set)
-  end
+  @spec make_members(atom()) :: [{atom(), node()}]
+  def make_members(cluster),
+    do: Enum.map(nodes(), fn node -> {cluster, node} end)
 
   # GenServer callbacks
 
@@ -47,10 +46,8 @@ defmodule Horde.NodeListener do
 
   defp listener_name(cluster), do: Module.concat(cluster, NodeListener)
 
-  defp set_members(cluster) do
-    members = Enum.map(nodes(), fn node -> {cluster, node} end)
-    :ok = Horde.Cluster.set_members(cluster, members)
-  end
+  defp set_members(cluster),
+    do: :ok = Horde.Cluster.set_members(cluster, make_members(cluster))
 
   defp nodes(), do: Node.list([:visible, :this])
 end

--- a/lib/horde/registry_impl.ex
+++ b/lib/horde/registry_impl.ex
@@ -87,6 +87,10 @@ defmodule Horde.RegistryImpl do
         nil ->
           state
 
+        :auto ->
+          Horde.NodeListener.initial_set(state.name)
+          state
+
         members ->
           members = Enum.map(members, &fully_qualified_name/1)
 


### PR DESCRIPTION
After realising I was about to re-implement it for the second time, I took a stab at creating a built-in version of [dynamic cluster membership support](https://hexdocs.pm/horde/libcluster.html#dynamic-cluster-membership). This allows the `members` option to be specified as `:auto` and uses the system described in the link above to keep cluster membership in sync with all visible nodes. It seemed like a common enough use case (and something I was mildly surprised to find was missing when I first picked up Horde) to warrant inclusion in the library itself.

I haven't written any docs for this yet - I figured I'd get some feedback first to see if you thought it was a worthwhile inclusion.