### PR TITLE
Add conflict_fun option

### DIFF
--- a/lib/horde/registry.ex
+++ b/lib/horde/registry.ex
@@ -44,6 +44,7 @@ defmodule Horde.Registry do
   @type option ::
           {:keys, :unique}
           | {:name, atom()}
+          | {:conflict_fun, (pid(), pid(), {atom(), term()}, atom() -> any())}
           | {:delta_crdt_options, [DeltaCrdt.crdt_option()]}
           | {:members, [Horde.Cluster.member()]}
 
@@ -98,6 +99,7 @@ defmodule Horde.Registry do
       :listeners,
       :meta,
       :keys,
+      :conflict_fun,
       :distribution_strategy,
       :members,
       :delta_crdt_options
@@ -127,6 +129,7 @@ defmodule Horde.Registry do
     end
 
     listeners = Keyword.get(options, :listeners, [])
+    conflict_fun = Keyword.get(options, :conflict_fun, nil)
     meta = Keyword.get(options, :meta, nil)
     members = Keyword.get(options, :members, [])
     delta_crdt_options = Keyword.get(options, :delta_crdt_options, [])
@@ -142,6 +145,7 @@ defmodule Horde.Registry do
       listeners: listeners,
       meta: meta,
       keys: keys,
+      conflict_fun: conflict_fun,
       distribution_strategy: distribution_strategy,
       members: members,
       delta_crdt_options: delta_crdt_options(delta_crdt_options)
@@ -169,6 +173,7 @@ defmodule Horde.Registry do
              listeners: flags.listeners,
              meta: flags.meta,
              keys: flags.keys,
+             conflict_fun: flags.conflict_fun,
              members: members(flags.members, name)
            ]}
         ]


### PR DESCRIPTION
So I was doing some work with the `Horde.Registry` stuff and hit a bit of an issue: If the registered process is a supervisor, then firing the `{:name_conflict, ...}` exit at it doesn't actually cause it to exit - instead it's silently discarded. And worse, if you're using an OTP supervisor, you can't intercept the message to cause the exit yourself. So after the conflict you're left with two supervisors still running, but only one registered.

I played around with a bunch of different ideas, but in the end the neatest one seemed to be to give the option of dealing with name conflicts yourself. So this change adds a `conflict_fun` option to `Horde.Registry`'s startup which replaces the exit with a call to a function (providing the same information that the exit contains). The user can then do whatever is required to shut down the conflict-losing process (and anything else they might want to do).

I did look at the undocumented (as far as I could see) `listeners` option - listening for the `:unregister` message would work, but it is also impossible to distinguish between an `:unregister` due to a name conflict and one due to any other cause.

If you're happy with this I'll add some documentation. If you'd prefer another approach, I'd be quite happy to code up anything that makes sense and solves the problem.