### PR TITLE
Fix Dynamic Supervisor Init typespec - Issue #181

### DIFF
--- a/lib/horde/dynamic_supervisor.ex
+++ b/lib/horde/dynamic_supervisor.ex
@@ -65,7 +65,11 @@ defmodule Horde.DynamicSupervisor do
           | {:delta_crdt_options, [DeltaCrdt.crdt_option()]}
           | {:process_redistribution, :active | :passive}
 
-  @callback init(options()) :: {:ok, options()}
+  @callback init(options()) ::
+              {:ok, map()}
+              | {:ok, tuple()}
+              | :ignore
+              | {:stop, {:bad_return, {atom(), :init, any()}}}
   @callback child_spec(options :: options()) :: Supervisor.child_spec()
 
   defmacro __using__(options) do


### PR DESCRIPTION
Hello! 👋 

This PR fixes issue #181.

Currently horde has a few typespecs errors and one of them is in the init function inside the `Horde.DynamicSupervisor`.

This fix reduces the total amount of typespec errors from 10 to 6.
To see the errors I suggest you to run dialyzer in the test environment(`MIX_ENV=test mix dialyzer`) since the tests contain code that uses the library giving more context to dialyzer. 

Thanks for you time and thank you very much for maintaining Horde! It's an awesome library! 🎉