### PR TITLE
Proper process redistribution after netsplit fails sometimes

### DIFF
--- a/loop.sh
+++ b/loop.sh
@@ -1,0 +1,4 @@
+while mix test test/netsplit_test.exs:44
+do
+echo "ran succesfully"
+done

--- a/test/support/my_supervision_tree.ex
+++ b/test/support/my_supervision_tree.ex
@@ -128,7 +128,6 @@ defmodule MyCluster do
         end
     end
   end
-
 end
 
 defmodule MyRegistry do
@@ -187,7 +186,6 @@ defmodule MyRegistry do
   def keys() do
     Horde.Registry.select(__MODULE__, [{{:"$1", :"$2", :"$3"}, [], [{{:"$1", :"$2"}}]}])
   end
-
 end
 
 defmodule MySupervisor do

--- a/test/support/my_supervision_tree.ex
+++ b/test/support/my_supervision_tree.ex
@@ -61,6 +61,74 @@ defmodule MyCluster do
   def whereis_server(node, name) do
     :rpc.call(node, MyCluster, :whereis_server, [name])
   end
+
+  def debug(nodes) when is_list(nodes) do
+    Enum.map(nodes, fn n ->
+      {n, debug(n)}
+    end)
+  end
+
+  def debug(n) when is_atom(n) do
+    :rpc.call(n, MyCluster, :debug, [])
+  end
+
+  @doc """
+  Returns member and registry content information. This function is used
+  to debug failed expectations in tests
+  """
+  def debug() do
+    [
+      members: [
+        supervisor: Horde.Cluster.members(MySupervisor),
+        registry: Horde.Cluster.members(MyRegistry)
+      ],
+      keys:
+        MyRegistry.keys()
+        |> Enum.map(fn {k, pid} ->
+          {k, pid, node(pid)}
+        end)
+    ]
+  end
+
+  @doc """
+  Checks whether the given server name is seen by all the nodes
+  in the given list. This function returns true, if all nodes are able
+  to see the same pid, and the node of that pid is one of those nodes.
+
+  """
+  def server_in_nodes?(nodes, name) do
+    Enum.reduce_while(nodes, [], fn n, pids ->
+      case whereis_server(n, name) do
+        :not_found ->
+          # At least one node is not able to locate the server
+          # return false
+          {:halt, :not_found}
+
+        pid when is_pid(pid) ->
+          # Collect the pid see by the node, for later
+          {:cont, [pid | pids]}
+      end
+    end)
+    |> case do
+      :not_found ->
+        false
+
+      pids ->
+        # All nodes are able to see a pid. Check whether all nodes
+        # see the same pid, and that pid is one of the nodes of original
+        # list
+        case Enum.uniq(pids) do
+          [pid] ->
+            Enum.member?(nodes, node(pid))
+
+          _ ->
+            # There is more than one distinct pid in the list
+            # Return false
+            false
+        end
+    end
+  end
+
 end
 
 defmodule MyRegistry do
@@ -115,6 +183,11 @@ defmodule MyRegistry do
         false
     end
   end
+
+  def keys() do
+    Horde.Registry.select(__MODULE__, [{{:"$1", :"$2", :"$3"}, [], [{{:"$1", :"$2"}}]}])
+  end
+
 end
 
 defmodule MySupervisor do


### PR DESCRIPTION
This PR adds a net split test that starts a 3 node cluster (node1, node2, node3), distributes 10 worker servers and creates two partitions: node1+node2 and node3. The test expects that all 10 workers are re-spawn on the partition formed by node1 and node2.

It works most of the time, but if you run the test in a loop, it ends up failing after a while.

Simply run the provided `loop.sh` script.  After a few iterations, the test should fail with a message such as:

```
Server server4 not running in one of: [:"node1@127.0.0.1", :"node2@127.0.0.1"]. Debug: ["node1@127.0.0.1": [members: [supervisor: [{MySupervisor, :"node1@127.0.0.1"}, {MySupervisor, :"node2@127.0.0.1"}], registry: [{MyRegistry, :"node1@127.0.0.1"}, {MyRegistry, :"node2@127.0.0.1"}]], keys: [{{MyServer, "server7"}, #PID<18937.258.0>, :"node2@127.0.0.1"}, {{MyServer, "server8"}, #PID<18937.259.0>, :"node2@127.0.0.1"}, {{MyServer, "server6"}, #PID<18937.257.0>, :"node2@127.0.0.1"}, {{MyServer, "server5"}, #PID<18886.265.0>, :"node1@127.0.0.1"}, {{MyServer, "server2"}, #PID<18886.306.0>, :"node1@127.0.0.1"}, {{MyServer, "server3"}, #PID<18886.262.0>, :"node1@127.0.0.1"}, {{MyServer, "server9"}, #PID<18886.292.0>, :"node1@127.0.0.1"}, {{MyServer, "server10"}, #PID<18886.307.0>, :"node1@127.0.0.1"}, {{MyServer, "server1"}, #PID<18886.305.0>, :"node1@127.0.0.1"}]], "node2@127.0.0.1": [members: [supervisor: [{MySupervisor, :"node1@127.0.0.1"}, {MySupervisor, :"node2@127.0.0.1"}], registry: [{MyRegistry, :"node1@127.0.0.1"}, {MyRegistry, :"node2@127.0.0.1"}]], keys: [{{MyServer, "server7"}, #PID<18937.258.0>, :"node2@127.0.0.1"}, {{MyServer, "server8"}, #PID<18937.259.0>, :"node2@127.0.0.1"}, {{MyServer, "server6"}, #PID<18937.257.0>, :"node2@127.0.0.1"}, {{MyServer, "server5"}, #PID<18886.265.0>, :"node1@127.0.0.1"}, {{MyServer, "server2"}, #PID<18886.306.0>, :"node1@127.0.0.1"}, {{MyServer, "server3"}, #PID<18886.262.0>, :"node1@127.0.0.1"}, {{MyServer, "server9"}, #PID<18886.292.0>, :"node1@127.0.0.1"}, {{MyServer, "server10"}, #PID<18886.307.0>, :"node1@127.0.0.1"}, {{MyServer, "server1"}, #PID<18886.305.0>, :"node1@127.0.0.1"}]]]
```


