### PR TITLE
Added method for controlling rebalance during operation.

### DIFF
--- a/lib/horde/dynamic_supervisor.ex
+++ b/lib/horde/dynamic_supervisor.ex
@@ -270,7 +270,8 @@ defmodule Horde.DynamicSupervisor do
   Setting redistribute_children to false disables redistribution when new nodes come up.
   """
   @spec redistribute_children(Supervisor.supervisor(), true | false) :: :ok
-  def redistribute_children(supervisor, enabled), do: GenServer.cast(supervisor, {:redistribute_children, enabled})
+  def redistribute_children(supervisor, enabled),
+    do: GenServer.cast(supervisor, {:redistribute_children, enabled})
 
   @doc """
   Waits for Horde.DynamicSupervisor to have quorum.

--- a/lib/horde/dynamic_supervisor.ex
+++ b/lib/horde/dynamic_supervisor.ex
@@ -63,7 +63,7 @@ defmodule Horde.DynamicSupervisor do
           | {:shutdown, integer()}
           | {:members, [Horde.Cluster.member()] | :auto}
           | {:delta_crdt_options, [DeltaCrdt.crdt_option()]}
-          | {:process_redistribution, :active | :passive}
+          | {:process_redistribution, :active | :manual | :passive}
 
   @callback init(options()) :: {:ok, options()} | :ignore
   @callback child_spec(options :: options()) :: Supervisor.child_spec()
@@ -261,6 +261,16 @@ defmodule Horde.DynamicSupervisor do
   This function delegates to all supervisors in the cluster and returns the aggregated output.
   """
   def count_children(supervisor), do: call(supervisor, :count_children)
+
+  @doc """
+  Enable/disable redistribution of the supervisor's children when process redistribution is set to manual.
+
+  When redistribute_children is true, children will be rebalanced to new nodes as they come up.
+  Calling this function also triggers the process if new nodes came up while the flag was false.
+  Setting redistribute_children to false disables redistribution when new nodes come up.
+  """
+  @spec redistribute_children(Supervisor.supervisor(), true | false) :: :ok
+  def redistribute_children(supervisor, enabled), do: GenServer.cast(supervisor, {:redistribute_children, enabled})
 
   @doc """
   Waits for Horde.DynamicSupervisor to have quorum.

--- a/test/dynamic_supervisor_test.exs
+++ b/test/dynamic_supervisor_test.exs
@@ -683,7 +683,8 @@ defmodule DynamicSupervisorTest do
              )
     end
 
-    test "processes should redistribute to new member nodes as they are added when config is :manual and the redistribution flag is set to true", context do
+    test "processes should redistribute to new member nodes as they are added when config is :manual and the redistribution flag is set to true",
+         context do
       n2_cspecs =
         LocalClusterHelper.expected_distribution_for(
           context.manual[:children],
@@ -705,7 +706,8 @@ defmodule DynamicSupervisorTest do
       assert LocalClusterHelper.supervisor_has_children?(context.manual[:n2], n2_cspecs)
     end
 
-    test "processes should redistribute to new member nodes when config is :manual and the redistribution flag is changed to true", context do
+    test "processes should redistribute to new member nodes when config is :manual and the redistribution flag is changed to true",
+         context do
       n2_cspecs =
         LocalClusterHelper.expected_distribution_for(
           context.manual[:children],


### PR DESCRIPTION
Added another config for process_redistribution, :manual.
When configured for manual, an element in the supervisor's CRDT is updated by the redistribute_children function so that all supervisors in the cluster can detect a change in the flag.
The diff callback on each node populates the supervisors' state which is then checked when a diff occurs and when node membership changes.

:manual could be folded into :active, but it seemed better to add a separate config.

Option 4 in #197 
