### PR TITLE
Replace remaining references to Horder.Supervisor

### DIFF
--- a/guides/getting_started.md
+++ b/guides/getting_started.md
@@ -50,7 +50,7 @@ See the documentation for `Horde.DynamicSupervisor` for more information.
 
 ## Starting Horde.Registry
 
-Horde.DynamicSupervisor is spreading your processes out over the cluster, but how do you know where all these processes are? Horde.Registry is the answer. We want Horde.Registry to be above Horde.Supervisor in the start-up order. 
+Horde.DynamicSupervisor is spreading your processes out over the cluster, but how do you know where all these processes are? Horde.Registry is the answer. We want Horde.Registry to be above Horde.DynamicSupervisor in the start-up order.
 
 This is what our example above looks like with Horde.Registry added in:
 

--- a/lib/horde/dynamic_supervisor.ex
+++ b/lib/horde/dynamic_supervisor.ex
@@ -8,7 +8,7 @@ defmodule Horde.DynamicSupervisor do
 
   Cluster membership is managed with `Horde.Cluster`. Joining a cluster can be done with `Horde.Cluster.set_members/2`. To take a node out of the cluster, call `Horde.Cluster.set_members/2` without that node in the list. Alternatively, setting the `members` startup option to `:auto` will make Horde auto-manage cluster membership so that all (and only) visible nodes are members of the cluster.
 
-  Each Horde.DynamicSupervisor node wraps its own local instance of `DynamicSupervisor`. `Horde.Supervisor.start_child/2` (for example) delegates to the local instance of DynamicSupervisor to actually start and monitor the child. The child spec is also written into the processes CRDT, along with a reference to the node on which it is running. When there is an update to the processes CRDT, Horde makes a comparison and corrects any inconsistencies (for example, if a conflict has been resolved and there is a process that no longer should be running on its node, it will kill that process and remove it from the local supervisor). So while most functions map 1:1 to the equivalent DynamicSupervisor functions, the eventually consistent nature of Horde requires extra behaviour not present in DynamicSupervisor.
+  Each Horde.DynamicSupervisor node wraps its own local instance of `DynamicSupervisor`. `Horde.DynamicSupervisor.start_child/2` (for example) delegates to the local instance of DynamicSupervisor to actually start and monitor the child. The child spec is also written into the processes CRDT, along with a reference to the node on which it is running. When there is an update to the processes CRDT, Horde makes a comparison and corrects any inconsistencies (for example, if a conflict has been resolved and there is a process that no longer should be running on its node, it will kill that process and remove it from the local supervisor). So while most functions map 1:1 to the equivalent DynamicSupervisor functions, the eventually consistent nature of Horde requires extra behaviour not present in DynamicSupervisor.
 
   ## Divergence from standard DynamicSupervisor behaviour
 
@@ -48,7 +48,7 @@ defmodule Horde.DynamicSupervisor do
   end
   ```
 
-  Then you can use `MySupervisor.child_spec/1` and `MySupervisor.start_link/1` in the same way as you'd use `Horde.DynamicSupervisor.child_spec/1` and `Horde.Supervisor.start_link/1`.
+  Then you can use `MySupervisor.child_spec/1` and `MySupervisor.start_link/1` in the same way as you'd use `Horde.DynamicSupervisor.child_spec/1` and `Horde.DynamicSupervisor.start_link/1`.
   """
   use Supervisor
 


### PR DESCRIPTION
Replaces remaining documentation references of `Horde.Supervisor` with `Horde.DynamicSupervisor`. Found this to be confusing when attempting to use `horde` for the first name.