### PR TITLE
Make collecting metrics safe

### DIFF
--- a/lib/horde/supervisor_telemetry_poller.ex
+++ b/lib/horde/supervisor_telemetry_poller.ex
@@ -1,5 +1,8 @@
 defmodule Horde.DynamicSupervisorTelemetryPoller do
   @moduledoc false
+
+  require Logger
+
   def child_spec(supervisor_impl_name) do
     %{
       id: :"#{supervisor_impl_name}_telemetry_poller",
@@ -29,5 +32,13 @@ defmodule Horde.DynamicSupervisorTelemetryPoller do
     :telemetry.execute([:horde, :supervisor, :supervised_process_count], metrics, %{
       name: supervisor_impl_name
     })
+  catch
+    :exit, reason ->
+      Logger.warn("""
+      Exit while fetching metrics from #{inspect(supervisor_impl_name)}.
+      Skip poll action. Reason: #{inspect(reason)}.
+      """)
+
+      :ok
   end
 end

--- a/test/supervisor_telemetry_poller_test.exs
+++ b/test/supervisor_telemetry_poller_test.exs
@@ -1,0 +1,37 @@
+defmodule SupervisorTelemetryPollerTest do
+  @moduledoc false
+
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  alias Horde.DynamicSupervisorTelemetryPoller, as: Poller
+
+  # Just a dummy GenServer to mock Supervisor.
+  defmodule SupervisorMock do
+    use GenServer
+
+    def init(_), do: {:ok, %{}}
+
+    def handle_call(:get_telemetry, _, state), do: {:reply, %{metrics: 1}, state}
+  end
+
+  setup do
+    {:ok, pid} = GenServer.start_link(SupervisorMock, %{test_case: :exit}, name: SupervisorMock)
+    Process.unlink(pid)
+
+    on_exit(fn -> Process.alive?(pid) && GenServer.stop(pid) end)
+  end
+
+  describe "when polls supervisors metrics with success" do
+    test "it sends metrics to telemetry" do
+      assert Poller.poll(SupervisorMock) == :ok
+    end
+  end
+
+  describe "when failes to poll supervisors metrics" do
+    test "it handles exit and logs reason" do
+      assert capture_log(fn -> :ok = Poller.poll(nil) end) =~ "Exit while fetching metrics from"
+    end
+  end
+end


### PR DESCRIPTION
## Make metrics polling safe

**In order to** avoid detachment of a poller that collects supervision metrics from Telemetry on `:EXIT` when supervisor is really busy redistributing processes, I suggest  to catch the `:EXIT` skipping a portion of metrics and log a warning. 