### PR TITLE
Add `Horde.Registry.delete_meta/2`

### DIFF
--- a/lib/horde/registry.ex
+++ b/lib/horde/registry.ex
@@ -235,6 +235,12 @@ defmodule Horde.Registry do
     GenServer.call(registry, {:unregister, name, self()})
   end
 
+  @doc "See `Registry.delete_meta/2`."
+  @spec delete_meta(registry :: Registry.registry(), name :: Registry.key()) :: :ok
+  def delete_meta(registry, name) when is_atom(registry) do
+    GenServer.call(registry, {:delete_meta, name, self()})
+  end
+
   @doc false
   def whereis(search), do: lookup(search)
 

--- a/lib/horde/registry.ex
+++ b/lib/horde/registry.ex
@@ -238,7 +238,7 @@ defmodule Horde.Registry do
   @doc "See `Registry.delete_meta/2`."
   @spec delete_meta(registry :: Registry.registry(), name :: Registry.key()) :: :ok
   def delete_meta(registry, name) when is_atom(registry) do
-    GenServer.call(registry, {:delete_meta, name, self()})
+    GenServer.call(registry, {:delete_meta, name})
   end
 
   @doc false

--- a/lib/horde/registry_impl.ex
+++ b/lib/horde/registry_impl.ex
@@ -181,7 +181,7 @@ defmodule Horde.RegistryImpl do
   end
 
   defp process_diff(state, {:remove, {:registry, key}}) do
-    :ets.match_delete(state.name, {key, :_})
+    :ets.delete(state.name, key)
 
     state
   end
@@ -333,12 +333,8 @@ defmodule Horde.RegistryImpl do
     {:reply, :ok, state}
   end
 
-  def handle_call({:delete_meta, key, pid}, _from, state) do
+  def handle_call({:delete_meta, key}, _from, state) do
     DeltaCrdt.mutate(crdt_name(state.name), :remove, [{:registry, key}], :infinity)
-
-    for listener <- state.listeners do
-      send(listener, {:delete_meta, state.name, key, pid})
-    end
 
     :ets.delete(state.name, key)
 


### PR DESCRIPTION
[`Registry.delete_meta/2`](https://github.com/elixir-lang/elixir/pull/10298) is coming to Elixir 1.11.0 but I don't think we need to wait for 1.11.0 to be released for this feature to already land in Horde :)