### PR TITLE
Fix typo 'failes' -> 'fails'

### DIFF
--- a/test/supervisor_telemetry_poller_test.exs
+++ b/test/supervisor_telemetry_poller_test.exs
@@ -29,7 +29,7 @@ defmodule SupervisorTelemetryPollerTest do
     end
   end
 
-  describe "when failes to poll supervisors metrics" do
+  describe "when fails to poll supervisors metrics" do
     test "it handles exit and logs reason" do
       assert capture_log(fn -> :ok = Poller.poll(nil) end) =~ "Exit while fetching metrics from"
     end


### PR DESCRIPTION
When searching for some stuff, I found this typo 🙂 