### PR TITLE
Change update_child_pid_horde to become a cast

### DIFF
--- a/lib/horde/processes_supervisor.ex
+++ b/lib/horde/processes_supervisor.ex
@@ -1063,7 +1063,7 @@ defmodule Horde.ProcessesSupervisor do
 
     case child_id_to_pid do
       %{^child_id => new_pid} ->
-        GenServer.call(state.root_name, {:update_child_pid, child_id, new_pid}, :infinity)
+        GenServer.cast(state.root_name, {:update_child_pid, child_id, new_pid})
 
       _pid_deleted ->
         GenServer.cast(state.root_name, {:disown_child_process, child_id})

--- a/test/dynamic_supervisor_deadlock_test.exs
+++ b/test/dynamic_supervisor_deadlock_test.exs
@@ -1,0 +1,66 @@
+defmodule DynamicSupervisorDeadlockTest do
+  require Logger
+  use ExUnit.Case
+
+  alias Horde.DynamicSupervisor
+
+  setup do
+    n1 = :"horde_#{:rand.uniform(100_000_000)}"
+
+    {:ok, horde_1_sup_pid} =
+      DynamicSupervisor.start_link(
+        name: n1,
+        strategy: :one_for_one,
+        delta_crdt_options: [sync_interval: 20]
+      )
+
+    # give the processes a couple ms to sync up
+    Process.sleep(100)
+
+    [
+      horde_1: n1,
+      horde_1_sup_pid: horde_1_sup_pid
+    ]
+  end
+
+  defmodule MyServer do
+    use GenServer
+
+    def start_link(arg) do
+      GenServer.start_link(__MODULE__, arg)
+    end
+
+    def init(:crash) do
+      Process.sleep(200)
+      {:ok, {}, 0}
+    end
+
+    def init(:normal) do
+      Process.sleep(200)
+      {:ok, {}}
+    end
+
+    def handle_info(:timeout, state) do
+      raise "crash!"
+    end
+  end
+
+  test "restart / init deadlock", context do
+    # given a process that crashes after a slow init
+    {:ok, _} =
+      Horde.DynamicSupervisor.start_child(context.horde_1, %{
+        restart: :permanent,
+        start: {MyServer, :start_link, [:crash]}
+      })
+
+    # when we start another "slow" init process
+    {:ok, _} =
+      Horde.DynamicSupervisor.start_child(context.horde_1, %{
+        restart: :permanent,
+        start: {MyServer, :start_link, [:normal]}
+      })
+
+    # this call used to hang
+    assert [_, _] = Horde.DynamicSupervisor.which_children(context.horde_1)
+  end
+end


### PR DESCRIPTION
Fixes #217

Although the actual change is only 2 LOC, the diff is rather large because I had to move the `set_child_pid` helper function down below the last `handle_cast`.