### PR TITLE
Implement ETS's as DynamicSupervisor internal data structures instead of Maps

### DIFF
--- a/lib/horde/dynamic_supervisor_impl.ex
+++ b/lib/horde/dynamic_supervisor_impl.ex
@@ -16,8 +16,8 @@ defmodule Horde.DynamicSupervisorImpl do
   defstruct name: nil,
             members: %{},
             members_info: %{},
-            processes_by_id: %{},
-            process_pid_to_id: %{},
+            processes_by_id: nil,
+            process_pid_to_id: nil,
             local_process_count: 0,
             waiting_for_quorum: [],
             supervisor_ref_to_name: %{},
@@ -27,7 +27,6 @@ defmodule Horde.DynamicSupervisorImpl do
             distribution_strategy: Horde.UniformDistribution
 
   def start_link(opts) do
-    IO.inspect("##########HORDE MODIFICADO2!!!###########")
     GenServer.start_link(__MODULE__, opts, Keyword.take(opts, [:name]))
   end
 

--- a/lib/horde/table_utils.ex
+++ b/lib/horde/table_utils.ex
@@ -1,0 +1,82 @@
+defmodule Horde.TableUtils do
+  @moduledoc false
+
+  def new_table(name) do
+    :ets.new(name, [:set, :protected])
+  end
+
+  def size_of(table) do
+    :ets.info(table, :size)
+  end
+
+  def get_item(table, id) do
+    case :ets.lookup(table, id) do
+      [{_, item}] -> item
+      [] -> nil
+    end
+  end
+
+  def delete_item(table, id) do
+    :ets.delete(table, id)
+    table
+  end
+
+  def pop_item(table, id) do
+    item = get_item(table, id)
+    delete_item(table, id)
+    {item, table}
+  end
+
+  def put_item(table, id, item) do
+    :ets.insert(table, {id, item})
+    table
+  end
+
+  def all_items_values(table) do
+    :ets.select(table, [{{:"$1", :"$2"}, [], [:"$2"]}])
+  end
+
+  def any_item(table, predicate) do
+    :ets.tab2list(table) |> Enum.any?(predicate)
+  end
+
+end
+
+
+#defmodule Horde.TableUtils do
+#  @moduledoc false
+#
+#  def new_table(name) do
+#    :ets.new(name, [:set, :private])
+#  end
+#
+#  def size_of(table) do
+#    map_size(table)
+#  end
+#
+#  def get_item(table, id) do
+#    Map.get(table, id)
+#  end
+#
+#  def delete_item(table, id) do
+#    Map.delete(table, id)
+#  end
+#
+#  def pop_item(table, id) do
+#    Map.pop(table, id)
+#  end
+#
+#  def put_item(table, id, item) do
+#    Map.put(table, id, item)
+#  end
+#
+#  def all_items_values(table) do
+#    Map.values(table)
+#  end
+#
+#  def any_item(table, predicate) do
+#    Enum.any?(table, predicate)
+#    #    :ets.tab2list(table) |> Enum.any?(predicate)
+#  end
+#
+#end

--- a/lib/horde/table_utils.ex
+++ b/lib/horde/table_utils.ex
@@ -39,44 +39,4 @@ defmodule Horde.TableUtils do
   def any_item(table, predicate) do
     :ets.tab2list(table) |> Enum.any?(predicate)
   end
-
 end
-
-
-#defmodule Horde.TableUtils do
-#  @moduledoc false
-#
-#  def new_table(name) do
-#    :ets.new(name, [:set, :private])
-#  end
-#
-#  def size_of(table) do
-#    map_size(table)
-#  end
-#
-#  def get_item(table, id) do
-#    Map.get(table, id)
-#  end
-#
-#  def delete_item(table, id) do
-#    Map.delete(table, id)
-#  end
-#
-#  def pop_item(table, id) do
-#    Map.pop(table, id)
-#  end
-#
-#  def put_item(table, id, item) do
-#    Map.put(table, id, item)
-#  end
-#
-#  def all_items_values(table) do
-#    Map.values(table)
-#  end
-#
-#  def any_item(table, predicate) do
-#    Enum.any?(table, predicate)
-#    #    :ets.tab2list(table) |> Enum.any?(predicate)
-#  end
-#
-#end

--- a/test/dynamic_supervisor_test.exs
+++ b/test/dynamic_supervisor_test.exs
@@ -466,7 +466,7 @@ defmodule DynamicSupervisorTest do
 
       Process.sleep(50)
 
-      assert :sys.get_state(:horde_transient).processes_by_id == %{}
+      assert Horde.TableUtils.size_of(:sys.get_state(:horde_transient).processes_by_id) == 0
     end
 
     test "transient process get removed from supervisor after exit" do
@@ -485,7 +485,7 @@ defmodule DynamicSupervisorTest do
 
       Process.sleep(200)
 
-      assert :sys.get_state(:horde_transient).processes_by_id == %{}
+      assert Horde.TableUtils.size_of(:sys.get_state(:horde_transient).processes_by_id) == 0
     end
 
     test "transient process does not get removed from supervisor after failed exit" do
@@ -503,7 +503,7 @@ defmodule DynamicSupervisorTest do
       Horde.DynamicSupervisor.start_child(:horde_transient, child_spec)
 
       processes = :sys.get_state(:horde_transient).processes_by_id
-      assert Enum.count(processes) == 1
+      assert Horde.TableUtils.size_of(processes) == 1
     end
   end
 

--- a/test/support/local_cluster_helper.ex
+++ b/test/support/local_cluster_helper.ex
@@ -46,7 +46,8 @@ defmodule LocalClusterHelper do
   def running_children(name) do
     sup_state = :sys.get_state(Process.whereis(name))
 
-    sup_state.processes_by_id |> :ets.tab2list()
+    sup_state.processes_by_id
+    |> :ets.tab2list()
     |> Enum.filter(fn {_id, {{sup_name, _}, _cspec, _pid}} ->
       Kernel.match?(^name, sup_name)
     end)

--- a/test/support/local_cluster_helper.ex
+++ b/test/support/local_cluster_helper.ex
@@ -46,7 +46,7 @@ defmodule LocalClusterHelper do
   def running_children(name) do
     sup_state = :sys.get_state(Process.whereis(name))
 
-    sup_state.processes_by_id
+    sup_state.processes_by_id |> :ets.tab2list()
     |> Enum.filter(fn {_id, {{sup_name, _}, _cspec, _pid}} ->
       Kernel.match?(^name, sup_name)
     end)


### PR DESCRIPTION
Hi, I've been using horde, in a project where I need a huge number of processes been supervised and distributed across nodes, when this number increase I note some performance degradation.. One of my guess when I inspected the DynamicSupervisorImpl were that maybe changing the maps processes_by_id and process_pid_to_id for an ETS, could have a positive effect in the performance..

Of course after the modifications, and do some tests, this change shows a improvement in the performance of spawning new childs in the supervisor, some numbers:

<img width="377" alt="image" src="https://user-images.githubusercontent.com/68216/105903469-e9d6fa00-5fed-11eb-86e3-99f901fee6e3.png">

<img width="421" alt="image" src="https://user-images.githubusercontent.com/68216/105903567-083cf580-5fee-11eb-8111-a424fa9edb64.png">

I tried to keep this change as local as posible thus not modifying anything outside this internal implementation detail.

I Hope this could help to enhance a bit this fantastic library.
