### PR TITLE
Pass along max_children config to ProcessesSupervisor

### DIFF
--- a/lib/horde/dynamic_supervisor.ex
+++ b/lib/horde/dynamic_supervisor.ex
@@ -205,6 +205,7 @@ defmodule Horde.DynamicSupervisor do
              type: :supervisor,
              name: supervisor_name(name),
              strategy: flags.strategy,
+             max_children: flags.max_children,
              max_restarts: flags.max_restarts,
              max_seconds: flags.max_seconds
            ]},


### PR DESCRIPTION
The `DynamicSupervisor` was not respecting the `max_children` config when starting children as the value was not being propagated to the `ProcessesSupervisor`. This PR passes along the value so the `ProcessesSupervisor` can enforce the setting.