### PR TITLE
Add optional node metadata

### DIFF
--- a/lib/horde/dynamic_supervisor.ex
+++ b/lib/horde/dynamic_supervisor.ex
@@ -64,6 +64,7 @@ defmodule Horde.DynamicSupervisor do
           | {:members, [Horde.Cluster.member()] | :auto}
           | {:delta_crdt_options, [DeltaCrdt.crdt_option()]}
           | {:process_redistribution, :active | :passive}
+          | {:metadata, %{atom() => any()} | %{}}
 
   @callback init(options()) :: {:ok, options()} | :ignore
   @callback child_spec(options :: options()) :: Supervisor.child_spec()
@@ -120,7 +121,8 @@ defmodule Horde.DynamicSupervisor do
       :distribution_strategy,
       :process_redistribution,
       :members,
-      :delta_crdt_options
+      :delta_crdt_options,
+      :metadata
     ]
 
     {sup_options, start_options} = Keyword.split(options, keys)
@@ -148,6 +150,7 @@ defmodule Horde.DynamicSupervisor do
     members = Keyword.get(options, :members, [])
     delta_crdt_options = Keyword.get(options, :delta_crdt_options, [])
     process_redistribution = Keyword.get(options, :process_redistribution, :passive)
+    metadata = Keyword.get(options, :metadata, %{})
 
     distribution_strategy =
       Keyword.get(
@@ -165,7 +168,8 @@ defmodule Horde.DynamicSupervisor do
       distribution_strategy: distribution_strategy,
       members: members,
       delta_crdt_options: delta_crdt_options(delta_crdt_options),
-      process_redistribution: process_redistribution
+      process_redistribution: process_redistribution,
+      metadata: metadata
     }
 
     {:ok, flags}
@@ -196,7 +200,8 @@ defmodule Horde.DynamicSupervisor do
              extra_arguments: flags.extra_arguments,
              distribution_strategy: flags.distribution_strategy,
              process_redistribution: flags.process_redistribution,
-             members: members(flags.members, name)
+             members: members(flags.members, name),
+             metadata: flags.metadata
            ]},
           {Horde.ProcessesSupervisor,
            [

--- a/lib/horde/dynamic_supervisor_impl.ex
+++ b/lib/horde/dynamic_supervisor_impl.ex
@@ -513,7 +513,9 @@ defmodule Horde.DynamicSupervisorImpl do
 
   defp update_member(state, {:add, {:member, member}, 1}) do
     new_members = Map.put_new(state.members, member, 1)
-    new_members_info = Map.put_new(state.members_info, member, uninitialized_member(member, state.metadata))
+
+    new_members_info =
+      Map.put_new(state.members_info, member, uninitialized_member(member, state.metadata))
 
     Map.put(state, :members, new_members)
     |> Map.put(:members_info, new_members_info)
@@ -556,7 +558,12 @@ defmodule Horde.DynamicSupervisorImpl do
     uninitialized_new_members_info =
       member_names(members)
       |> Map.new(fn name ->
-        {name, %Horde.DynamicSupervisor.Member{name: name, status: :uninitialized, metadata: state.metadata}}
+        {name,
+         %Horde.DynamicSupervisor.Member{
+           name: name,
+           status: :uninitialized,
+           metadata: state.metadata
+         }}
       end)
 
     new_members_info =


### PR DESCRIPTION
I think it would be cool to be able to add some extra data to DynamicSupervisor.Member struct as it might be helpful to have some additional info besides name and state. For example, when creating a custom distribution strategy, a member could be chosen by its metadata (for example its region).