### PR TITLE
Fix crashes related to missing child ids in lookup table

### DIFF
--- a/lib/horde/dynamic_supervisor_impl.ex
+++ b/lib/horde/dynamic_supervisor_impl.ex
@@ -431,6 +431,7 @@ defmodule Horde.DynamicSupervisorImpl do
 
               case current_member do
                 %{status: :dead} ->
+                  DeltaCrdt.delete(crdt_name(state.name), {:process, child_spec.id}, :infinity)
                   {_response, state} = add_child(randomize_child_id(child_spec), state)
 
                   state

--- a/lib/horde/processes_supervisor.ex
+++ b/lib/horde/processes_supervisor.ex
@@ -806,9 +806,7 @@ defmodule Horde.ProcessesSupervisor do
     %{children: children} = state
 
     case children do
-      %{^pid => restarting_args} ->
-        {:restarting, child} = restarting_args
-
+      %{^pid => {:restarting, child}} ->
         case restart_child(pid, child, state) do
           {:ok, state} -> {:noreply, state}
           {:shutdown, state} -> {:stop, :shutdown, state}

--- a/test/dynamic_supervisor_test.exs
+++ b/test/dynamic_supervisor_test.exs
@@ -446,6 +446,18 @@ defmodule DynamicSupervisorTest do
 
       Process.sleep(5000)
       assert_receive {:starting, 5000}, 100
+
+      # we have 2 supervised processes
+      processes = :sys.get_state(:horde_2_graceful).processes_by_id
+      assert Horde.TableUtils.size_of(processes) == 2
+
+      # peek into the remaining supervisor, getting the supervised pids
+      pids =
+        :sys.get_state(:horde_2_graceful).processes_by_id
+        |> :ets.tab2list()
+        |> Enum.map(&(elem(&1, 1) |> elem(2)))
+
+      assert Enum.all?(pids, &Process.alive?/1)
     end
   end
 


### PR DESCRIPTION
I noticed that when a cluster is restarting, Horde tends to crash
because it does some administration that is incorrect. The child
lookup for the linked ETS table can fail but this was not handled on
all places in the Dynamic Supervisor implementation.

This fix addresses three places that resulted in crashes because `nil`
was not handled from the get_item / pop_item calls.

Note that there were several other places where this was already
addressed.