### PR TITLE
Pin telemetry and telemetry_poller dependencies to `~> 1.0`

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -31,8 +31,8 @@ defmodule Horde.MixProject do
     [
       {:delta_crdt, "~> 0.6.2"},
       {:libring, "~> 1.4"},
-      {:telemetry, "~> 1.0.0 or ~> 0.4.0"},
-      {:telemetry_poller, "~> 1.0.0 or ~> 0.5.0"},
+      {:telemetry, "~> 1.0 or ~> 0.4.0"},
+      {:telemetry_poller, "~> 1.0 or ~> 0.5.0"},
       {:ex_doc, "~> 0.16", only: :dev, runtime: false},
       {:benchee, "> 0.0.1", only: :dev, runtime: false},
       {:stream_data, "~> 0.4", only: :test},


### PR DESCRIPTION
This allows `Horde` to be used by applications which have a dependency on `telemetry` version >= `1.1.0`.