### PR TITLE
Added new UniformRandomDistribution strategy

### DIFF
--- a/lib/horde/distribution_strategy.ex
+++ b/lib/horde/distribution_strategy.ex
@@ -4,7 +4,11 @@ defmodule Horde.DistributionStrategy do
   @moduledoc """
   Define your own distribution strategy by implementing this behaviour and configuring Horde to use it.
 
-  See `Horde.UniformQuorumDistribution` and `Horde.UniformDistribution` for examples.
+  A few distribution stategies are included in Horde, namely:
+
+  - `Horde.UniformDistribution`
+  - `Horde.UniformQuorumDistribution`
+  - `Horde.UniformRandomDistribution`
   """
   @callback choose_node(identifier :: String.t(), members :: [Horde.DynamicSupervisor.Member.t()]) ::
               {:ok, Horde.DynamicSupervisor.Member.t()} | {:error, reason :: String.t()}

--- a/lib/horde/dynamic_supervisor.ex
+++ b/lib/horde/dynamic_supervisor.ex
@@ -108,7 +108,7 @@ defmodule Horde.DynamicSupervisor do
 
   @doc """
   Works like `DynamicSupervisor.start_link/1`. Extra options are documented here:
-  - `:distribution_strategy`, defaults to `Horde.UniformDistribution` but can also be set to `Horde.UniformQuorumDistribution`. `Horde.UniformQuorumDistribution` enforces a quorum and will shut down all processes on a node if it is split from the rest of the cluster.
+  - `:distribution_strategy`, defaults to `Horde.UniformDistribution`, but more are available - see `Horde.DistributionStrategy`
   """
   def start_link(options) when is_list(options) do
     keys = [

--- a/lib/horde/uniform_distribution.ex
+++ b/lib/horde/uniform_distribution.ex
@@ -2,7 +2,10 @@ defmodule Horde.UniformDistribution do
   @behaviour Horde.DistributionStrategy
 
   @moduledoc """
-  Distributes processes to nodes uniformly using a hash ring
+  Distributes processes to nodes uniformly using a hash ring.
+
+  Given the *same* set of members, it will always start
+  the same process on the same node.
   """
 
   def choose_node(identifier, members) do

--- a/lib/horde/uniform_quorum_distribution.ex
+++ b/lib/horde/uniform_quorum_distribution.ex
@@ -3,6 +3,8 @@ defmodule Horde.UniformQuorumDistribution do
 
   @moduledoc """
   Distributes processes to nodes uniformly using a hash ring. Contains a quorum mechanism to handle netsplits.
+
+  It enforces a quorum and will shut down all processes on a node if it is split from the rest of the cluster.
   """
   require Integer
 

--- a/lib/horde/uniform_random_distribution.ex
+++ b/lib/horde/uniform_random_distribution.ex
@@ -1,0 +1,33 @@
+defmodule Horde.UniformRandomDistribution do
+  @behaviour Horde.DistributionStrategy
+
+  @moduledoc """
+  Distributes processes with an uniform probability to
+  any node that is alive.
+  """
+
+  @doc """
+  Selects a random alive node.
+  """
+  def choose_node(_identifier, members) do
+    members
+    |> Enum.filter(&match?(%{status: :alive}, &1))
+    |> case do
+      [] ->
+        {:error, :no_alive_nodes}
+
+      members ->
+        chosen_member =
+          Enum.shuffle(members)
+          |> List.first()
+
+        {:ok, chosen_member}
+    end
+  end
+
+  @doc """
+  Quorum checks are not enforced, so the process will be
+  (re)started on  both sides of a netsplit.
+  """
+  def has_quorum?(_members), do: true
+end


### PR DESCRIPTION
I added a very simple Random distribution strategy, and its test.

Most of the changes were in the ExDoc part, so that available strategies are linked from within Horde.DistributionStrategy, in the perspective of adding more in the future.

Fixes https://github.com/derekkraan/horde/issues/251 though it does not change the interface of DistributionStrategy so it's a bit more limited - but this requires a separate topic.
