### PR TITLE
Supervisor: old child specs remained in CRDT after process handoff

### DIFF
--- a/lib/horde/dynamic_supervisor_impl.ex
+++ b/lib/horde/dynamic_supervisor_impl.ex
@@ -422,6 +422,7 @@ defmodule Horde.DynamicSupervisorImpl do
 
               case current_member do
                 %{status: :dead} ->
+                  DeltaCrdt.delete(crdt_name(state.name), {:process, child_spec.id}, :infinity)
                   {_response, state} = add_child(randomize_child_id(child_spec), state)
 
                   state

--- a/test/dynamic_supervisor_test.exs
+++ b/test/dynamic_supervisor_test.exs
@@ -446,6 +446,18 @@ defmodule DynamicSupervisorTest do
 
       Process.sleep(5000)
       assert_receive {:starting, 5000}, 100
+
+      # we have 2 supervised processes
+      processes = :sys.get_state(:horde_2_graceful).processes_by_id
+      assert Horde.TableUtils.size_of(processes) == 2
+
+      # peek into the remaining supervisor, getting the supervised pids
+      pids =
+        :sys.get_state(:horde_2_graceful).processes_by_id
+        |> :ets.tab2list()
+        |> Enum.map(&(elem(&1, 1) |> elem(2)))
+
+      assert Enum.all?(pids, &Process.alive?/1)
     end
   end
 


### PR DESCRIPTION
When an existing child spec was added to the CRDT during process handoff, the old child spec is never removed from the CRDT, creating lingering child specs which results in "zombie" processes spawning when a new supervisor is started.

Fixes #262