### PR TITLE
Remove warnings and switch to the erpc module 

### DIFF
--- a/lib/horde/registry.ex
+++ b/lib/horde/registry.ex
@@ -418,7 +418,7 @@ defmodule Horde.Registry do
     n = node(pid)
 
     Node.list() |> Enum.member?(n) &&
-      :rpc.call(n, Process, :alive?, [pid])
+      :erpc.call(n, Process, :alive?, [pid])
   end
 
   defp member_in_cluster?(registry, member) do

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule Horde.MixProject do
       {:stream_data, "~> 0.4", only: :test},
       {:local_cluster, "~> 1.1", only: :test},
       {:schism, "~> 1.0.1", only: :test},
-      {:dialyxir, "~> 1.0.0-rc.6", only: [:dev, :test], runtime: false},
+      {:dialyxir, "~> 1.0.0-rc.6", only: [:dev], runtime: false},
       {:test_app, path: "test_app", only: [:test]}
     ]
   end

--- a/test/cluster_test.exs
+++ b/test/cluster_test.exs
@@ -206,7 +206,7 @@ defmodule ClusterTest do
       nodes = LocalCluster.start_nodes(cluster, 2)
 
       on_exit(fn ->
-        :rpc.multicall(Node.list([:visible, :this]), Horde.NodeListener, :clear_all, [])
+        :erpc.multicall(Node.list([:visible, :this]), Horde.NodeListener, :clear_all, [])
       end)
 
       {:ok, cluster: cluster, nodes: nodes, all_nodes: Enum.sort([node() | nodes])}

--- a/test/dynamic_supervisor_deadlock_test.exs
+++ b/test/dynamic_supervisor_deadlock_test.exs
@@ -40,7 +40,7 @@ defmodule DynamicSupervisorDeadlockTest do
       {:ok, {}}
     end
 
-    def handle_info(:timeout, state) do
+    def handle_info(:timeout, _state) do
       raise "crash!"
     end
   end

--- a/test/local_cluster_test.exs
+++ b/test/local_cluster_test.exs
@@ -82,7 +82,7 @@ defmodule LocalClusterTest do
       pid when is_pid(pid) ->
         pid
 
-      x ->
+      _ ->
         Process.sleep(200)
         do_await_replication(target, id)
     end
@@ -101,7 +101,7 @@ defmodule LocalClusterTest do
             nodes = rpc(target, Node, :list, [])
 
             Logger.info(
-              "found #{inspect(pid)} on node: #{inspect(node(pid))}, target #{inspect(node)}, nodes: #{inspect(nodes)}"
+              "found #{inspect(pid)} on node: #{inspect(node(pid))}, target #{inspect(node())}, nodes: #{inspect(nodes)}"
             )
 
             Process.sleep(200)

--- a/test/network_partition_test.exs
+++ b/test/network_partition_test.exs
@@ -5,20 +5,20 @@ defmodule NetworkPartitionTest do
     nodes = LocalCluster.start_nodes("cluster-#{:rand.uniform(9_999_999)}", 2)
 
     for n <- nodes do
-      :rpc.call(n, Application, :ensure_all_started, [:test_app])
+      :erpc.call(n, Application, :ensure_all_started, [:test_app])
     end
 
     [nodes: nodes]
   end
 
   test "recovers as expected in case of network partition", %{nodes: [n1, n2] = nodes} do
-    assert {:ok, pid1} =
+    assert {:ok, _pid1} =
              Horde.DynamicSupervisor.start_child(
                {TestSup, n1},
                {IgnoreWorker, {:via, Horde.Registry, {TestReg, IgnoreWorker}}}
              )
 
-    assert {:ok, pid2} =
+    assert {:ok, _pid2} =
              Horde.DynamicSupervisor.start_child(
                {TestSup, n2},
                {IgnoreWorker, {:via, Horde.Registry, {TestReg, IgnoreWorker}}}
@@ -28,8 +28,8 @@ defmodule NetworkPartitionTest do
     sup_members = for n <- nodes, do: {TestSup, n}
 
     for n <- nodes do
-      :ok = :rpc.call(n, Horde.Cluster, :set_members, [TestReg, reg_members])
-      :ok = :rpc.call(n, Horde.Cluster, :set_members, [TestSup, sup_members])
+      :ok = :erpc.call(n, Horde.Cluster, :set_members, [TestReg, reg_members])
+      :ok = :erpc.call(n, Horde.Cluster, :set_members, [TestSup, sup_members])
     end
 
     Schism.partition([n1])
@@ -44,17 +44,17 @@ defmodule NetworkPartitionTest do
     assert [{_, pid, _, _}] = Horde.DynamicSupervisor.which_children({TestSup, n1})
     assert [{_, ^pid, _, _}] = Horde.DynamicSupervisor.which_children({TestSup, n2})
 
-    assert true = :rpc.call(node(pid), Process, :alive?, [pid])
+    assert true = :erpc.call(node(pid), Process, :alive?, [pid])
   end
 
   test "recovers as expected in case of node stopping", %{nodes: [n1, n2] = nodes} do
-    assert {:ok, pid1} =
+    assert {:ok, _pid1} =
              Horde.DynamicSupervisor.start_child(
                {TestSup, n1},
                {IgnoreWorker, {:via, Horde.Registry, {TestReg, IgnoreWorker}}}
              )
 
-    assert {:ok, pid2} =
+    assert {:ok, _pid2} =
              Horde.DynamicSupervisor.start_child(
                {TestSup, n2},
                {IgnoreWorker, {:via, Horde.Registry, {TestReg, IgnoreWorker}}}
@@ -67,8 +67,8 @@ defmodule NetworkPartitionTest do
     sup_members = for n <- nodes, do: {TestSup, n}
 
     for n <- nodes do
-      :ok = :rpc.call(n, Horde.Cluster, :set_members, [TestReg, reg_members])
-      :ok = :rpc.call(n, Horde.Cluster, :set_members, [TestSup, sup_members])
+      :ok = :erpc.call(n, Horde.Cluster, :set_members, [TestReg, reg_members])
+      :ok = :erpc.call(n, Horde.Cluster, :set_members, [TestSup, sup_members])
     end
 
     Process.sleep(100)
@@ -80,6 +80,6 @@ defmodule NetworkPartitionTest do
 
     assert [{_, pid, _, _}] = Horde.DynamicSupervisor.which_children({TestSup, n1})
 
-    assert true = :rpc.call(node(pid), Process, :alive?, [pid])
+    assert true = :erpc.call(node(pid), Process, :alive?, [pid])
   end
 end

--- a/test/support/my_supervision_tree.ex
+++ b/test/support/my_supervision_tree.ex
@@ -47,7 +47,7 @@ defmodule MyCluster do
   end
 
   def start_server(node, name) do
-    :rpc.call(node, MyCluster, :start_server, [name])
+    :erpc.call(node, MyCluster, :start_server, [name])
   end
 
   def start_server(name) do
@@ -59,7 +59,7 @@ defmodule MyCluster do
   end
 
   def whereis_server(node, name) do
-    :rpc.call(node, MyCluster, :whereis_server, [name])
+    :erpc.call(node, MyCluster, :whereis_server, [name])
   end
 end
 
@@ -103,7 +103,7 @@ defmodule MyRegistry do
   end
 
   def alive?(node) do
-    :rpc.call(node, MyRegistry, :alive?, [])
+    :erpc.call(node, MyRegistry, :alive?, [])
   end
 
   def alive?() do
@@ -145,7 +145,7 @@ defmodule MySupervisor do
   end
 
   def alive?(node) do
-    :rpc.call(node, MySupervisor, :alive?, [])
+    :erpc.call(node, MySupervisor, :alive?, [])
   end
 
   def alive?() do


### PR DESCRIPTION
This PR aims to remove some warnings. Also use the erpc module explicitly when possible.