### PR TITLE
Fix crashes related to missing child ids in lookup table 

### DIFF
--- a/lib/horde/processes_supervisor.ex
+++ b/lib/horde/processes_supervisor.ex
@@ -806,9 +806,7 @@ defmodule Horde.ProcessesSupervisor do
     %{children: children} = state
 
     case children do
-      %{^pid => restarting_args} ->
-        {:restarting, child} = restarting_args
-
+      %{^pid => {:restarting, child}} ->
         case restart_child(pid, child, state) do
           {:ok, state} -> {:noreply, state}
           {:shutdown, state} -> {:stop, :shutdown, state}


### PR DESCRIPTION
I noticed that when a cluster is restarting, Horde tends to crash
because it does some administration that is incorrect. The child
lookup for the linked ETS table can fail but this was not handled on
all places in the Dynamic Supervisor implementation.

This fix addresses three places that resulted in crashes because nil
was not handled from the get_item / pop_item calls.

Note that there were several other places where this was already
addressed.