### PR TITLE
feat(DynamicSupervisor): respect `extra_arguments` configuration

### DIFF
--- a/lib/horde/dynamic_supervisor.ex
+++ b/lib/horde/dynamic_supervisor.ex
@@ -204,6 +204,7 @@ defmodule Horde.DynamicSupervisor do
              root_name: name,
              type: :supervisor,
              name: supervisor_name(name),
+             extra_arguments: flags.extra_arguments,
              strategy: flags.strategy,
              max_restarts: flags.max_restarts,
              max_seconds: flags.max_seconds


### PR DESCRIPTION
Pass the `extra_arguments` flag to the `ProcessSupervisor`.

Similar to #238