### PR TITLE
Adding TTL to proxied messages

### DIFF
--- a/lib/horde/dynamic_supervisor.ex
+++ b/lib/horde/dynamic_supervisor.ex
@@ -60,6 +60,7 @@ defmodule Horde.DynamicSupervisor do
           | {:max_seconds, integer()}
           | {:extra_arguments, [term()]}
           | {:distribution_strategy, Horde.DistributionStrategy.t()}
+          | {:proxy_message_ttl, integer() | :infinity}
           | {:shutdown, integer()}
           | {:members, [Horde.Cluster.member()] | :auto}
           | {:delta_crdt_options, [DeltaCrdt.crdt_option()]}
@@ -119,6 +120,7 @@ defmodule Horde.DynamicSupervisor do
       :strategy,
       :distribution_strategy,
       :process_redistribution,
+      :proxy_message_ttl,
       :members,
       :delta_crdt_options
     ]
@@ -156,6 +158,13 @@ defmodule Horde.DynamicSupervisor do
         Horde.UniformDistribution
       )
 
+    proxy_message_ttl =
+      Keyword.get(
+        options,
+        :proxy_message_ttl,
+        :infinity
+      )
+
     flags = %{
       strategy: strategy,
       max_restarts: max_restarts,
@@ -163,6 +172,7 @@ defmodule Horde.DynamicSupervisor do
       max_children: max_children,
       extra_arguments: extra_arguments,
       distribution_strategy: distribution_strategy,
+      proxy_message_ttl: proxy_message_ttl,
       members: members,
       delta_crdt_options: delta_crdt_options(delta_crdt_options),
       process_redistribution: process_redistribution
@@ -196,6 +206,7 @@ defmodule Horde.DynamicSupervisor do
              extra_arguments: flags.extra_arguments,
              distribution_strategy: flags.distribution_strategy,
              process_redistribution: flags.process_redistribution,
+             proxy_message_ttl: flags.proxy_message_ttl,
              members: members(flags.members, name)
            ]},
           {Horde.ProcessesSupervisor,


### PR DESCRIPTION
A message proxied to another node by the DynamicSupervisor can be proxied again. This is clearly evident when using a large number of nodes and picking `Horde.UniformRandomDistribution` as a distribution strategy. Pushing your luck with that strategy 🍀

This commit contains an implementation which limits the amount of times a message can be proxied before expiring, by adding a TTL which works similar to the TTL on IP packets.

The default TTL is `:infinity`, which means the implementation is backwards compatible. Message with TTL :infinity can bounce around between nodes forever. The max TTL can be set to any integer via the new `:proxy_message_ttl` option. Each "hop" decreases the TTL for a message by 1 one. When a message with a TTL of zero needs to be proxied, an error will be returned to the `reply_to` process.

With a distribution strategy of `Horde.UniformDistribution` the issue of passing messages around forever is unlikely, as nodes tend to agree on the outcome of `choose_node`. However, a recent incident whilst upgrading to OTP 27 brought this issue to light, as the underlying algorithm for choosing nodes was broken on our already upgraded nodes. This causes message to be proxied between our nodes infinitely.

Please feel free to pass any form of judgement on the implementation. This is just a jumping-off platform and it can only go uphill from here 👍 

## With TTL of 2:
```mermaid
graph TD;
p[process A] -- call start_child() --> A[node A];
A -- proxy start_child(ttl: 2) --> B[node B];
B -- proxy start_child(ttl: 1) --> C[node C];
C -- reply {:error, :proxy_operation_ttl_expired, ...} --> p;

```