### PR TITLE
Race condition during Registry.lookup/2

### DIFF
--- a/lib/horde/registry.ex
+++ b/lib/horde/registry.ex
@@ -421,7 +421,6 @@ defmodule Horde.Registry do
       :erpc.call(n, Process, :alive?, [pid])
   catch
     :error, {:erpc, :noconnection} -> false
-    :error, reason -> reraise reason, __STACKTRACE__
     type, reason -> :erlang.raise(type, reason, __STACKTRACE__)
   end
 


### PR DESCRIPTION
This addresses an unlikely, but annoyingly consistent during some recent local testing, race condition in `Registry.lookup/2` wherein the target node of the pid disconnects between the call to `Node.list/0` and `:erpc.call/4` resulting in an exception of `:error, {:erpc, :noconnection}`.

I've chosen to only handle the specific case mentioned and otherwise let all other exception behaviour to continue as this specific case at least appears it should return `false`.