### PR TITLE
Add typespecs to internal modules and quorum tests

### DIFF
--- a/lib/horde/registry_impl.ex
+++ b/lib/horde/registry_impl.ex
@@ -7,6 +7,18 @@ defmodule Horde.RegistryImpl do
 
   defmodule State do
     @moduledoc false
+
+    @type t :: %__MODULE__{
+            name: atom() | nil,
+            nodes: MapSet.t(node()),
+            members: MapSet.t({atom(), node()}),
+            registry_ets_table: atom() | nil,
+            pids_ets_table: atom() | nil,
+            keys_ets_table: atom() | nil,
+            members_ets_table: atom() | nil,
+            listeners: [atom()]
+          }
+
     defstruct name: nil,
               nodes: MapSet.new(),
               members: MapSet.new(),

--- a/lib/horde/signal_shutdown.ex
+++ b/lib/horde/signal_shutdown.ex
@@ -4,6 +4,7 @@ defmodule Horde.SignalShutdown do
   use GenServer
   require Logger
 
+  @spec child_spec(keyword()) :: Supervisor.child_spec()
   def child_spec(options) do
     %{
       id: __MODULE__,
@@ -11,11 +12,15 @@ defmodule Horde.SignalShutdown do
     }
   end
 
+  @impl GenServer
+  @spec init([GenServer.server()]) :: {:ok, [GenServer.server()]}
   def init(signal_to) do
     Process.flag(:trap_exit, true)
     {:ok, signal_to}
   end
 
+  @impl GenServer
+  @spec terminate(term(), [GenServer.server()]) :: :ok
   def terminate(_reason, signal_to) do
     Enum.each(signal_to, fn destination ->
       :ok = GenServer.call(destination, :horde_shutting_down)

--- a/test/uniform_quorum_distribution_test.exs
+++ b/test/uniform_quorum_distribution_test.exs
@@ -59,4 +59,49 @@ defmodule UniformQuorumDistributionTest do
       end
     end
   end
+
+  test "has_quorum? returns false for empty list" do
+    refute Horde.UniformQuorumDistribution.has_quorum?([])
+  end
+
+  test "has_quorum? returns nil when all members are shutting_down" do
+    members = [
+      %{status: :shutting_down, name: :a},
+      %{status: :shutting_down, name: :b},
+      %{status: :shutting_down, name: :c}
+    ]
+
+    assert Horde.UniformQuorumDistribution.has_quorum?(members) == nil
+  end
+
+  test "has_quorum? returns true when majority is alive" do
+    members = [
+      %{status: :alive, name: :a},
+      %{status: :alive, name: :b},
+      %{status: :dead, name: :c}
+    ]
+
+    assert Horde.UniformQuorumDistribution.has_quorum?(members)
+  end
+
+  test "has_quorum? returns false when majority is dead" do
+    members = [
+      %{status: :alive, name: :a},
+      %{status: :dead, name: :b},
+      %{status: :dead, name: :c}
+    ]
+
+    refute Horde.UniformQuorumDistribution.has_quorum?(members)
+  end
+
+  test "choose_node returns quorum_not_met when no quorum" do
+    members = [
+      %{status: :alive, name: :a},
+      %{status: :dead, name: :b},
+      %{status: :dead, name: :c}
+    ]
+
+    assert {:error, :quorum_not_met} =
+             Horde.UniformQuorumDistribution.choose_node(%{id: :test, start: {:test}}, members)
+  end
 end


### PR DESCRIPTION
## Summary

- Added `@type t` to `RegistryImpl.State` struct for better static analysis
- Added `@spec` and `@impl` annotations to `SignalShutdown` callbacks
- Added unit tests for `UniformQuorumDistribution` edge cases: empty members, all shutting_down, majority alive vs dead, and quorum_not_met error path

## Test plan

- [x] `mix compile` passes with no warnings
- [x] All quorum distribution tests pass (1 property, 5 tests)