### PR TITLE
fix(registry): behave as expected under supervision

### DIFF
--- a/lib/horde/registry.ex
+++ b/lib/horde/registry.ex
@@ -175,7 +175,7 @@ defmodule Horde.Registry do
            ]}
         ]
         |> maybe_add_node_manager(flags.members, name)
-        |> Supervisor.init(strategy: :one_for_all)
+        |> Supervisor.init(strategy: :one_for_all, max_restarts: 0)
 
       :ignore ->
         :ignore

--- a/test/dynamic_supervisor_test.exs
+++ b/test/dynamic_supervisor_test.exs
@@ -778,4 +778,19 @@ defmodule DynamicSupervisorTest do
       assert %{ok: process_count} == result_count
     end
   end
+
+  test "when part of a supervision tree, behaves as expected" do
+    start_supervised!(ASupervisionTree)
+
+    pid_initial = AServer.pid()
+
+    ASupervisionTree.supervisor()
+    |> Process.exit(:kill)
+
+    Process.sleep(100)
+
+    pid_final = AServer.pid()
+
+    assert pid_initial != pid_final
+  end
 end

--- a/test/registry_test.exs
+++ b/test/registry_test.exs
@@ -905,6 +905,21 @@ defmodule RegistryTest do
     end
   end
 
+  test "when part of a supervision tree, behaves as expected" do
+    start_supervised!(ASupervisionTree)
+
+    pid_initial = AServer.pid()
+
+    ASupervisionTree.registry()
+    |> Process.exit(:kill)
+
+    Process.sleep(100)
+
+    pid_final = AServer.pid()
+
+    assert pid_initial != pid_final
+  end
+
   defp register_task(registry, key, value) do
     parent = self()
 

--- a/test/support/my_supervision_tree.ex
+++ b/test/support/my_supervision_tree.ex
@@ -17,6 +17,57 @@ defmodule MySupervisionTree do
   end
 end
 
+defmodule ASupervisionTree do
+  use Supervisor
+
+  def start_link(arg) do
+    Supervisor.start_link(__MODULE__, arg, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_arg) do
+    registry_args = [
+      members: :auto,
+      keys: :unique,
+      name: :"h#{System.unique_integer([:positive])}"
+    ]
+
+    supervisor_args = [
+      members: :auto,
+      strategy: :one_for_one,
+      name: :"h#{System.unique_integer([:positive])}"
+    ]
+
+    children = [
+      {Horde.Registry, registry_args},
+      {Horde.DynamicSupervisor, supervisor_args},
+      AServer
+    ]
+
+    Supervisor.init(children, strategy: :rest_for_one)
+  end
+
+  def registry do
+    Supervisor.which_children(__MODULE__)
+    |> Enum.find_value(fn {_id, pid, _type, modules} -> modules == [Horde.Registry] && pid end)
+    |> Supervisor.which_children()
+    |> Enum.find_value(fn {_id, pid, _type, modules} ->
+      modules == [Horde.RegistryImpl] && pid
+    end)
+  end
+
+  def supervisor do
+    Supervisor.which_children(__MODULE__)
+    |> Enum.find_value(fn {_id, pid, _type, modules} ->
+      modules == [Horde.DynamicSupervisor] && pid
+    end)
+    |> Supervisor.which_children()
+    |> Enum.find_value(fn {_id, pid, _type, modules} ->
+      modules == [Horde.DynamicSupervisorImpl] && pid
+    end)
+  end
+end
+
 defmodule MyCluster do
   def set_members(cluster) do
     nodes = nodes(cluster)
@@ -225,5 +276,23 @@ defmodule MyServer do
   def handle_info({:EXIT, _, {:name_conflict, {{_, name}, _}, _registry, winner}}, state) do
     IO.inspect(conflict: name, looser: {self(), node(self())}, winner: {winner, node(winner)})
     {:stop, :shutdown, state}
+  end
+end
+
+defmodule AServer do
+  use GenServer
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, nil, name: __MODULE__)
+  end
+
+  def pid do
+    GenServer.whereis(__MODULE__)
+  end
+
+  @impl GenServer
+  def init(_) do
+    Process.flag(:trap_exit, true)
+    {:ok, nil}
   end
 end


### PR DESCRIPTION
`Horde.DynamicSupervisor` already uses `max_restarts: 0` to cascade the crash and work as expected under `:rest_for_one` or `:one_for_all` supervisors.

Use the same strategy for `Horde.Registry`, and test that both modules behave as expected.